### PR TITLE
ci: add build flag `EXCLUDE_DELPHES`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
             echo "aname = ${{matrix.aname}}"
             echo "recon = ${{matrix.recon}}"
             echo "[CI] flatten tree of Delphes files"
-            find . -name "*.root" -print | grep -E '^x_delphes' | tee tmp.list
+            find . -name "*.root" -print | grep -E '^x_delphes' > tmp.list
             cat tmp.list | while read f; do mv -v $f datarec/; done
             cat x_delphes*/delphes.config > delphes.config
             sort -nr -o delphes.config{,}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        minq2: [1, 10, 100, 1000]
+        minq2: [1, 10, 100, 1000] # note: keep consistent with `download-artifact` with name `x_delphes_*`
     steps:
       - uses: actions/checkout@v3
       - uses: cvmfs-contrib/github-action-cvmfs@v3
@@ -118,7 +118,7 @@ jobs:
             cat delphes.config
       - uses: actions/upload-artifact@v3
         with:
-          name: delphes_${{env.ebeam_en}}x${{env.pbeam_en}}_q2min${{matrix.minq2}}_output
+          name: x_delphes_q2min${{matrix.minq2}}
           retention-days: 1
           path: |
             datarec/*.root
@@ -179,7 +179,20 @@ jobs:
           name: x_build_all
       - uses: actions/download-artifact@v3
         with:
-          path: datarec
+          name: x_delphes_q2min1
+          path: x_delphes_q2min1
+      - uses: actions/download-artifact@v3
+        with:
+          name: x_delphes_q2min10
+          path: x_delphes_q2min10
+      - uses: actions/download-artifact@v3
+        with:
+          name: x_delphes_q2min100
+          path: x_delphes_q2min100
+      - uses: actions/download-artifact@v3
+        with:
+          name: x_delphes_q2min1000
+          path: x_delphes_q2min1000
       - uses: cvmfs-contrib/github-action-cvmfs@v3
       - uses: eic/run-cvmfs-osg-eic-shell@main
         with:
@@ -190,9 +203,9 @@ jobs:
             echo "aname = ${{matrix.aname}}"
             echo "recon = ${{matrix.recon}}"
             echo "[CI] flatten tree of Delphes files"
-            find datarec -name "*.root" -print | tee tmp.list
+            find -name "*.root" -print | grep -E '^x_delphes' | tee tmp.list
             cat tmp.list | while read f; do mv -v $f datarec/; done
-            cat datarec/delphes*/delphes.config > delphes.config
+            cat x_delphes*/delphes.config > delphes.config
             sort -nr -o delphes.config{,}
             echo "[CI] cat delphes.config"
             cat delphes.config
@@ -430,7 +443,6 @@ jobs:
         run: |
           rm -vr results/x_*
           rm -vr results/root_analysis_*
-          rm -vr results/delphes_*_output
           find results -name "*.root" -print | xargs rm -v
           rm -v results/*y_minima*/*/canv*.png
           tree results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
             echo "aname = ${{matrix.aname}}"
             echo "recon = ${{matrix.recon}}"
             echo "[CI] flatten tree of Delphes files"
-            find -name "*.root" -print | grep -E '^x_delphes' | tee tmp.list
+            find . -name "*.root" -print | grep -E '^x_delphes' | tee tmp.list
             cat tmp.list | while read f; do mv -v $f datarec/; done
             cat x_delphes*/delphes.config > delphes.config
             sort -nr -o delphes.config{,}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           run: |
             echo "[CI] build sidis-eic"
             source environ.sh
-            make
+            EXCLUDE_DELPHES=1 make
       - uses: actions/upload-artifact@v3
         with:
           name: x_build_no_delphes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
             echo "aname = ${{matrix.aname}}"
             echo "recon = ${{matrix.recon}}"
             echo "[CI] flatten tree of Delphes files"
-            find . -name "*.root" -print | grep -E '^x_delphes' > tmp.list
+            find -name "*.root" -print | tee tmp.list
             cat tmp.list | while read f; do mv -v $f datarec/; done
             cat x_delphes*/delphes.config > delphes.config
             sort -nr -o delphes.config{,}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
             echo "[CI] cat delphes.config"
             cat delphes.config
             echo "[CI] ANALYSIS MACRO"
-            root -b -q 'macro/ci/analysis_${{matrix.aname}}.C("delphes.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fastsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
+            root -b -q macro/ci/include_delphes.C 'macro/ci/analysis_${{matrix.aname}}.C("delphes.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fastsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
       - uses: actions/upload-artifact@v3
         with:
           name: root_analysis_fastsim_${{matrix.aname}}_${{matrix.recon}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
 jobs:
 
 # BUILD ---------------------------------------------------------------------------
-  build:
+  build_all:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,7 +34,7 @@ jobs:
             make
       - uses: actions/upload-artifact@v3
         with:
-          name: x_build
+          name: x_build_all
           retention-days: 1
           path: |
             # sidis-eic
@@ -50,11 +50,37 @@ jobs:
             deps/adage/lib
             deps/adage/src/*Dict.cxx
 
+  build_no_delphes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: cvmfs-contrib/github-action-cvmfs@v3
+      - uses: eic/run-cvmfs-osg-eic-shell@main
+        with:
+          platform-release: "jug_xl:nightly"
+          run: |
+            echo "[CI] build sidis-eic"
+            source environ.sh
+            make
+      - uses: actions/upload-artifact@v3
+        with:
+          name: x_build_no_delphes
+          retention-days: 1
+          path: |
+            # sidis-eic
+            lib
+            src/*Dict.cxx
+            # mstwpdf
+            deps/mstwpdf/*.o
+            deps/mstwpdf/*.so
+            # adage
+            deps/adage/lib
+            deps/adage/src/*Dict.cxx
+
 # DELPHES ---------------------------------------------------------------------------
 
 # run delphes on a hepmc file
   delphes_fastsim:
-    needs: build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -62,9 +88,6 @@ jobs:
         minq2: [1, 10, 100, 1000]
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
-        with:
-          name: x_build
       - uses: cvmfs-contrib/github-action-cvmfs@v3
       - uses: eic/run-cvmfs-osg-eic-shell@main
         env:
@@ -82,6 +105,8 @@ jobs:
             while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
             echo "====="
             ls -lh datagen
+            echo "[CI] install delphes"
+            deps/install_delphes.sh
             echo "[CI] RUN DELPHES"
             chmod u+x deps/delphes/DelphesHepMC3
             for hepmc in datagen/*.hepmc.gz; do deps/run_delphes.sh $hepmc; done
@@ -133,7 +158,7 @@ jobs:
 # run analysis macros matrix for fastsim
   analysis_fastsim:
     needs: 
-      - build
+      - build_all
       - delphes_fastsim
     runs-on: ubuntu-latest
     strategy:
@@ -151,7 +176,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
-          name: x_build
+          name: x_build_all
       - uses: actions/download-artifact@v3
         with:
           path: datarec
@@ -182,7 +207,7 @@ jobs:
 # run analysis macros matrix for fullsim
   analysis_fullsim:
     needs: 
-      - build
+      - build_no_delphes
       - download_fullsim
     runs-on: ubuntu-latest
     strategy:
@@ -200,7 +225,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
-          name: x_build
+          name: x_build_no_delphes
       - uses: actions/download-artifact@v3
         with:
           name: x_fullsim
@@ -281,7 +306,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
-          name: x_build
+          name: x_build_no_delphes
       - uses: actions/download-artifact@v3
         with:
           name: root_analysis_${{matrix.mode}}_${{matrix.aname}}_${{matrix.recon}}
@@ -349,7 +374,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
-          name: x_build
+          name: x_build_no_delphes
       - uses: actions/download-artifact@v3
         with:
           name: root_analysis_fastsim_${{matrix.aname}}_${{matrix.recon}}

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,15 @@ clean:
 deps: delphes mstwpdf adage
 deps-clean: delphes-clean mstwpdf-clean adage-clean
 delphes:
-	@echo "\n===== DELPHES ====="
-	@cd ${DELPHES_HOME}; $(MAKE)
+	@if [ -z "${EXCLUDE_DELPHES}" ]; then \
+		echo "\n===== DELPHES ====="; \
+		cd ${DELPHES_HOME}; $(MAKE); \
+	fi
 delphes-clean:
-	@echo "\n===== CLEAN DELPHES ====="
-	@cd ${DELPHES_HOME}; $(MAKE) clean
+	@if [ -z "${EXCLUDE_DELPHES}" ]; then \
+		echo "\n===== CLEAN DELPHES ====="; \
+		cd ${DELPHES_HOME}; $(MAKE) clean; \
+	fi
 mstwpdf:
 	@echo "\n===== MSTWPDF ====="
 	@cd ${MSTWPDF_HOME}; $(MAKE)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ all: deps sidis-eic
 all-clean: deps-clean clean
 sidis-eic:
 	@echo "\n===== SIDIS-EIC ====="
-	@ln -sf ${DELPHES_HOME}/external ./
+	@if [ -z "${EXCLUDE_DELPHES}" ]; then \
+		ln -svf ${DELPHES_HOME}/external ./; \
+	fi
 	@cd src; $(MAKE)
 clean:
 	@echo "\n===== CLEAN SIDIS-EIC ====="

--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ make <dependency>        # build a particular `<dependency>`
 make <dependency>-clean  # clean a particular `<dependency>`
 ```
 
+Additional build options are available:
+- `INCLUDE_CENTAURO=1 make` will build with `fastjet` plugin `Centauro`; note that `Centauro` is not included
+  with `Delphes` by default
+- `EXCLUDE_DELPHES=1 make` will build `sidis-eic` without Delphes, which is primarily used to expedite CI workflows
+
 ## Quick Start
 
 - If you're ready to try the software hands-on, follow the [tutorials](tutorial/README.md) in 

--- a/config.mk
+++ b/config.mk
@@ -24,8 +24,6 @@ ifndef EXCLUDE_DELPHES
 endif
 
 # DELPHES plugin: Fastjet Centauro
-# usage: `INCLUDE_CENTAURO=1 make`
-# FIXME(jet): test and add to documentation
 ifdef INCLUDE_CENTAURO
 	LIBS += -L${DELPHES_HOME}/external/fastjet/plugins/Centauro -lCentauro
 	DEPS += -I${DELPHES_HOME}/external/fastjet/plugins/Centauro

--- a/config.mk
+++ b/config.mk
@@ -24,12 +24,13 @@ ifndef EXCLUDE_DELPHES
 endif
 
 # DELPHES plugin: Fastjet Centauro
-INCCENTAURO = 0
-ifeq ($(INCCENTAURO),1)
+# usage: `INCLUDE_CENTAURO=1 make`
+# FIXME(jet): test and add to documentation
+ifdef INCLUDE_CENTAURO
 	LIBS += -L${DELPHES_HOME}/external/fastjet/plugins/Centauro -lCentauro
 	DEPS += -I${DELPHES_HOME}/external/fastjet/plugins/Centauro
+	FLAGS += -DINCLUDE_CENTAURO
 endif
-FLAGS += -DINCCENTAURO=$(INCCENTAURO)
 
 # MSTWPDF
 DEPS += -I${MSTWPDF_HOME}

--- a/config.mk
+++ b/config.mk
@@ -8,7 +8,7 @@ FLAGS += -fmax-errors=3
 # extra flags for Mac OS
 UNAME := $(shell uname)
 ifeq ($(UNAME), Darwin)
-    FLAGS += -std=c++11
+	FLAGS += -std=c++11
 endif
 
 # ROOT
@@ -17,14 +17,17 @@ LIBS = $(shell root-config --glibs)
 #LIBS += -lMinuit -lRooFitCore -lRooFit -lRooStats -lProof -lMathMore
 
 # DELPHES
-DEPS += -I${DELPHES_HOME} -I${DELPHES_HOME}/external
-LIBS += -L${DELPHES_HOME} -lDelphes
+ifndef EXCLUDE_DELPHES
+	DEPS += -I${DELPHES_HOME} -I${DELPHES_HOME}/external
+	LIBS += -L${DELPHES_HOME} -lDelphes
+	FLAGS += -DINCLUDE_DELPHES
+endif
 
 # DELPHES plugin: Fastjet Centauro
 INCCENTAURO = 0
 ifeq ($(INCCENTAURO),1)
-LIBS += -L${DELPHES_HOME}/external/fastjet/plugins/Centauro -lCentauro
-DEPS += -I${DELPHES_HOME}/external/fastjet/plugins/Centauro
+	LIBS += -L${DELPHES_HOME}/external/fastjet/plugins/Centauro -lCentauro
+	DEPS += -I${DELPHES_HOME}/external/fastjet/plugins/Centauro
 endif
 FLAGS += -DINCCENTAURO=$(INCCENTAURO)
 
@@ -38,5 +41,5 @@ LIBS += -L${ADAGE_HOME}/lib -lAdage
 
 # SIDIS-EIC
 ifndef SIDIS_EIC_HOME
-$(error "ERROR: run 'source environ.sh' before building")
+	$(error "ERROR: run 'source environ.sh' before building")
 endif

--- a/macro/ci/analysis_p_eta.C
+++ b/macro/ci/analysis_p_eta.C
@@ -14,7 +14,9 @@ void analysis_p_eta(
   Analysis *A;
   if(outfilePrefix.Contains("fullsim"))
        A = new AnalysisAthena(  infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
+#ifdef INCLUDE_DELPHES
   else A = new AnalysisDelphes( infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
+#endif
 
   A->SetReconMethod(reconMethod); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state

--- a/macro/ci/analysis_x_q2.C
+++ b/macro/ci/analysis_x_q2.C
@@ -18,7 +18,9 @@ void analysis_x_q2(
   Analysis *A;
   if(outfilePrefix.Contains("fullsim"))
        A = new AnalysisAthena(  infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
+#ifdef INCLUDE_DELPHES
   else A = new AnalysisDelphes( infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
+#endif
 
   A->SetReconMethod(reconMethod); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state

--- a/macro/ci/analysis_yRatio.C
+++ b/macro/ci/analysis_yRatio.C
@@ -14,7 +14,9 @@ void analysis_yRatio(
   Analysis *A;
   if(outfilePrefix.Contains("fullsim"))
        A = new AnalysisAthena(  infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
+#ifdef INCLUDE_DELPHES
   else A = new AnalysisDelphes( infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
+#endif
 
   A->SetReconMethod(reconMethod); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state

--- a/macro/ci/include_delphes.C
+++ b/macro/ci/include_delphes.C
@@ -1,0 +1,3 @@
+{
+#define INCLUDE_DELPHES
+}

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -50,9 +50,6 @@ Analysis::Analysis(
   availableBinSchemes.insert({ "phiS",  "#phi_{S}"    });
   availableBinSchemes.insert({ "tSpin", "spin"        });
   availableBinSchemes.insert({ "lSpin", "spinL"       });
-  /* jets */
-  availableBinSchemes.insert({ "ptJet", "jet p_{T}"   });
-  availableBinSchemes.insert({ "zJet",  "jet z"       });
 
 
   // available final states
@@ -66,7 +63,6 @@ Analysis::Analysis(
   finalStateToTitle.insert({ "KpTrack",  "K^{+} tracks"   });
   finalStateToTitle.insert({ "KmTrack",  "K^{-} tracks"   });
   finalStateToTitle.insert({ "pTrack",   "p^{+} tracks"   });
-  finalStateToTitle.insert({ "jet",      "jets"           });
   // - PID -> finalState ID
   PIDtoFinalState.insert({  211,  "pipTrack" });
   PIDtoFinalState.insert({ -211,  "pimTrack" });
@@ -74,6 +70,14 @@ Analysis::Analysis(
   PIDtoFinalState.insert({ -321,  "KmTrack"  });
   PIDtoFinalState.insert({  2212, "pTrack"   });
 
+  // jets
+#ifdef INCLUDE_DELPHES
+  // available variables for binning
+  availableBinSchemes.insert({ "ptJet", "jet p_{T}" });
+  availableBinSchemes.insert({ "zJet",  "jet z"     });
+  // available final states
+  finalStateToTitle.insert({ "jet", "jets" });
+#endif
 
   // kinematics reconstruction methods
   // - choose one of these methods using `SetReconMethod(TString name)`
@@ -264,8 +268,10 @@ void Analysis::Prepare() {
   HD->SetBinSchemeValue("tSpin", [this](){ return (Double_t)kin->tSpin;         });
   HD->SetBinSchemeValue("lSpin", [this](){ return (Double_t)kin->lSpin;         });
   /* jets */
+#ifdef INCLUDE_DELPHES
   HD->SetBinSchemeValue("ptJet", [this](){ return kin->pTjet;                   });
   HD->SetBinSchemeValue("zJet",  [this](){ return kin->zjet;                    });
+#endif
 
   // some bin schemes values are checked here, instead of by CutDef checks ("External" cut type)
   // - the lambda must return a boolean
@@ -332,19 +338,10 @@ void Analysis::Prepare() {
     HS->DefineHist2D("depolCAvsQ2", "Q^{2}", "C/A",      "GeV^{2}", "", NBINS, 1, 3000, NBINS, 0, 2.5, true, false);
     HS->DefineHist2D("depolVAvsQ2", "Q^{2}", "V/A",      "GeV^{2}", "", NBINS, 1, 3000, NBINS, 0, 2.5, true, false);
     HS->DefineHist2D("depolWAvsQ2", "Q^{2}", "W/A",      "GeV^{2}", "", NBINS, 1, 3000, NBINS, 0, 2.5, true, false);
-     
     // -- single-hadron cross sections
     //HS->DefineHist1D("Q_xsec","Q","GeV",10,0.5,10.5,false,true); // linear
     HS->DefineHist1D("Q_xsec","Q","GeV",10,1.0,10.0,true,true); // log
     HS->Hist("Q_xsec")->SetMinimum(1e-10);
-    // -- jet kinematics
-    HS->DefineHist1D("pT_jet","jet p_{T}","GeV", NBINS, 1e-2, 50);
-    HS->DefineHist1D("mT_jet","jet m_{T}","GeV", NBINS, 1e-2, 20);
-    HS->DefineHist1D("z_jet","jet z","", NBINS,0, 1);
-    HS->DefineHist1D("eta_jet","jet #eta_{lab}","", NBINS,-5,5);
-    HS->DefineHist1D("qT_jet","jet q_{T}", "GeV", NBINS, 0, 10.0);
-    HS->DefineHist1D("jperp","j_{#perp}","GeV", NBINS, 0, 3.0);
-    HS->DefineHist1D("qTQ_jet","jet q_{T}/Q","", NBINS, 0, 3.0);
     // -- resolutions
     HS->DefineHist1D("x_Res","x-x_{true}","", NBINS, -0.5, 0.5);
     HS->DefineHist1D("y_Res","y-y_{true}","", NBINS, -0.2, 0.2);
@@ -396,6 +393,16 @@ void Analysis::Prepare() {
         NBINS,-TMath::Pi(),TMath::Pi(),
         NBINS,-TMath::Pi(),TMath::Pi()
         );
+    // -- jet kinematics
+#ifdef INCLUDE_DELPHES
+    HS->DefineHist1D("pT_jet","jet p_{T}","GeV", NBINS, 1e-2, 50);
+    HS->DefineHist1D("mT_jet","jet m_{T}","GeV", NBINS, 1e-2, 20);
+    HS->DefineHist1D("z_jet","jet z","", NBINS,0, 1);
+    HS->DefineHist1D("eta_jet","jet #eta_{lab}","", NBINS,-5,5);
+    HS->DefineHist1D("qT_jet","jet q_{T}", "GeV", NBINS, 0, 10.0);
+    HS->DefineHist1D("jperp","j_{#perp}","GeV", NBINS, 0, 3.0);
+    HS->DefineHist1D("qTQ_jet","jet q_{T}/Q","", NBINS, 0, 3.0);
+#endif
   });
   HD->ExecuteAndClearOps();
 
@@ -643,6 +650,7 @@ void Analysis::FillHistosTracks() {
 
 
 // jets
+#ifdef INCLUDE_DELPHES
 void Analysis::FillHistosJets() {
 
   // check which bins to fill
@@ -668,6 +676,7 @@ void Analysis::FillHistosJets() {
   //   with this jet
   HD->ExecuteOps(true);
 };
+#endif
 
 
 // destructor

--- a/src/Analysis.h
+++ b/src/Analysis.h
@@ -96,7 +96,9 @@ class Analysis : public TNamed
 
     // FillHistos methods: fill histograms
     void FillHistosTracks();
+#ifdef INCLUDE_DELPHES
     void FillHistosJets();
+#endif
 
     // shared objects
     SimpleTree *ST;
@@ -131,9 +133,11 @@ class Analysis : public TNamed
     Double_t eleP,maxEleP;
     Double_t elePtrue, maxElePtrue;
     int pid;
-    fastjet::PseudoJet jet;
     TString finalStateID;
     Double_t wTrack,wJet;
+#ifdef INCLUDE_DELPHES
+    fastjet::PseudoJet jet;
+#endif
 
     // binning names / titles / etc.
     std::map<TString,TString> availableBinSchemes;

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -174,7 +174,7 @@ void AnalysisDelphes::Execute() {
       // - check PID, to see if it's a final state we're interested in for
       //   histograms; if not, proceed to next track
       // pid = trk->PID; //NOTE: trk->PID is currently not smeared so it just returns the truth-level PID
-      pid = kin->getTrackPID( // get smeared PID
+      pid = kin->GetTrackPID( // get smeared PID
           trk,
           itpfRICHTrack,
           itDIRCepidTrack, itDIRChpidTrack,

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -239,9 +239,9 @@ void AnalysisDelphes::Execute() {
     finalStateID = "jet";
     if(activeFinalStates.find(finalStateID)!=activeFinalStates.end()) {
 
-      #ifdef INCLUDE_CENTAURO
+#ifdef INCLUDE_CENTAURO
       if(useBreitJets) kin->GetBreitFrameJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);
-      #endif
+#endif
 
       Double_t Q2weightFactor = GetEventQ2Weight(kinTrue->Q2, chain->GetTreeNumber());
       wJet = Q2weightFactor * weightJet->GetWeight(*kinTrue); // TODO: should we separate weights for breit and non-breit jets?
@@ -254,10 +254,10 @@ void AnalysisDelphes::Execute() {
       for(int i = 0; i < kin->jetsRec.size(); i++){
 
         if(useBreitJets) {
-          #ifdef INCLUDE_CENTAURO
+#ifdef INCLUDE_CENTAURO
           jet = kin->breitJetsRec[i];
           kin->CalculateBreitJetKinematics(jet);
-          #endif
+#endif
         } else {
           jet = kin->jetsRec[i];
           kin->CalculateJetKinematics(jet);

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -239,7 +239,7 @@ void AnalysisDelphes::Execute() {
     finalStateID = "jet";
     if(activeFinalStates.find(finalStateID)!=activeFinalStates.end()) {
 
-      #if INCCENTAURO == 1
+      #ifdef INCLUDE_CENTAURO
       if(useBreitJets) kin->GetBreitFrameJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);
       #endif
 
@@ -254,7 +254,7 @@ void AnalysisDelphes::Execute() {
       for(int i = 0; i < kin->jetsRec.size(); i++){
 
         if(useBreitJets) {
-          #if INCCENTAURO == 1
+          #ifdef INCLUDE_CENTAURO
           jet = kin->breitJetsRec[i];
           kin->CalculateBreitJetKinematics(jet);
           #endif

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -754,7 +754,7 @@ void Kinematics::CalculateJetKinematics(fastjet::PseudoJet jet){
 };
 
 
-#if INCCENTAURO == 1
+#ifdef INCLUDE_CENTAURO
 void Kinematics::GetBreitFrameJets(
   TObjArrayIter itEFlowTrack, TObjArrayIter itEFlowPhoton,
   TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itParticle
@@ -906,7 +906,7 @@ void Kinematics::CalculateBreitJetKinematics(fastjet::PseudoJet jet){
   }
 
 };
-#endif // ifdef INCCENTAURO
+#endif // ifdef INCLUDE_CENTAURO
 #endif // ifdef INCLUDE_DELPHES
 // end DELPHES-only methods //////////////////////////////////////////////////////
 

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -29,7 +29,6 @@
 #ifdef INCLUDE_CENTAURO
 #include "fastjet/plugins/Centauro/Centauro.hh"
 #endif
-//using namespace fastjet;
 #endif
 
 using std::map;

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -23,7 +23,9 @@
 #include "TRandomGen.h"
 
 // Delphes
+#ifdef INCLUDE_DELPHES
 #include "classes/DelphesClasses.h"
+#endif
 
 // Fastjet
 #include "fastjet/ClusterSequence.hh"
@@ -48,6 +50,15 @@ class Kinematics : public TObject
     void CalculateHadronKinematics();
 
     // hadronic final state (HFS)
+    void AddToHFS(TLorentzVector p4_);
+    void SubtractElectronFromHFS();
+    void ResetHFS();
+
+
+    // DELPHES-specific methods //////////////////////////
+#ifdef INCLUDE_DELPHES
+
+    // hadronic final state (HFS)
     void GetHFS(
         TObjArrayIter itTrack,
         TObjArrayIter itEFlowTrack,
@@ -59,12 +70,9 @@ class Kinematics : public TObject
         TObjArrayIter itdualRICHagTrack, TObjArrayIter itdualRICHcfTrack
         );
     void GetTrueHFS(TObjArrayIter itParticle);
-    void ResetHFS();
-    void SubtractElectronFromHFS();
-    void AddToHFS(TLorentzVector p4_);
 
     // PID
-    int getTrackPID(
+    int GetTrackPID(
         Track *track,
         TObjArrayIter itpfRICHTrack,
         TObjArrayIter itDIRCepidTrack, TObjArrayIter itDIRChpidTrack,
@@ -78,13 +86,16 @@ class Kinematics : public TObject
         TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itParticle
         );
     void CalculateJetKinematics(fastjet::PseudoJet jet);
-    #if INCCENTAURO == 1
+#if INCCENTAURO == 1
     void GetBreitFrameJets(
         TObjArrayIter itEFlowTrack, TObjArrayIter itEFlowPhoton,
         TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itParticle
         );
     void CalculateBreitJetKinematics(fastjet::PseudoJet jet);
-    #endif
+#endif // ifdef INCCENTAURO
+#endif // ifdef INCLUDE_DELPHES
+    // end DELPHES-specific methods //////////////////////////
+
 
     // kinematics (should be Double_t, if going in SimpleTree)
     Double_t W,Q2,Nu,x,y,s; // DIS

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -25,14 +25,12 @@
 // Delphes
 #ifdef INCLUDE_DELPHES
 #include "classes/DelphesClasses.h"
-#endif
-
-// Fastjet
 #include "fastjet/ClusterSequence.hh"
 #ifdef INCLUDE_CENTAURO
 #include "fastjet/plugins/Centauro/Centauro.hh"
 #endif
 //using namespace fastjet;
+#endif
 
 using std::map;
 using std::cout;
@@ -130,11 +128,12 @@ class Kinematics : public TObject
     TLorentzVector vecEleBeam, vecIonBeam;
     TLorentzVector vecElectron, vecW, vecQ;
     TLorentzVector vecHadron;
-    // jets
+
+#ifdef INCLUDE_DELPHES
+    // jet objects
     std::vector<fastjet::PseudoJet> jetsRec, jetsTrue;
     std::vector<fastjet::PseudoJet> breitJetsRec, breitJetsTrue;
     std::map<double, int> jetConstituents;
-
     fastjet::ClusterSequence csRec;
     fastjet::ClusterSequence csTrue;
 
@@ -143,6 +142,7 @@ class Kinematics : public TObject
     std::vector<double> zhad_jet;
     // struck quark information
     Double_t quarkpT;
+#endif
 
 
     // particle masses

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -29,7 +29,7 @@
 
 // Fastjet
 #include "fastjet/ClusterSequence.hh"
-#if INCCENTAURO == 1
+#ifdef INCLUDE_CENTAURO
 #include "fastjet/plugins/Centauro/Centauro.hh"
 #endif
 //using namespace fastjet;
@@ -86,13 +86,13 @@ class Kinematics : public TObject
         TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itParticle
         );
     void CalculateJetKinematics(fastjet::PseudoJet jet);
-#if INCCENTAURO == 1
+#ifdef INCLUDE_CENTAURO
     void GetBreitFrameJets(
         TObjArrayIter itEFlowTrack, TObjArrayIter itEFlowPhoton,
         TObjArrayIter itEFlowNeutralHadron, TObjArrayIter itParticle
         );
     void CalculateBreitJetKinematics(fastjet::PseudoJet jet);
-#endif // ifdef INCCENTAURO
+#endif // ifdef INCLUDE_CENTAURO
 #endif // ifdef INCLUDE_DELPHES
     // end DELPHES-specific methods //////////////////////////
 

--- a/src/LinkDef.h
+++ b/src/LinkDef.h
@@ -25,9 +25,7 @@
 #pragma link C++ class Analysis+;
 #pragma link C++ class AnalysisAthena+;
 #pragma link C++ class AnalysisEcce+;
-#ifdef INCLUDE_DELPHES
 #pragma link C++ class AnalysisDelphes+;
-#endif
 
 // postprocessing
 #pragma link C++ class PostProcessor+;

--- a/src/LinkDef.h
+++ b/src/LinkDef.h
@@ -21,11 +21,15 @@
 #pragma link C++ class WeightsProduct+;
 #pragma link C++ class WeightsSum+;
 
-// analysis algorithms
+// analysis event loop classes
 #pragma link C++ class Analysis+;
-#pragma link C++ class AnalysisDelphes+;
 #pragma link C++ class AnalysisAthena+;
 #pragma link C++ class AnalysisEcce+;
+#ifdef INCLUDE_DELPHES
+#pragma link C++ class AnalysisDelphes+;
+#endif
+
+// postprocessing
 #pragma link C++ class PostProcessor+;
 
 #endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -12,6 +12,10 @@ LINKDEF := LinkDef.h
 # source code (with $(DICT) and $(LINKDEF) moved to end of lists for rootcling)
 SOURCES := $(filter-out $(DICT),    $(wildcard *.cxx) $(wildcard sfset/*.cxx) $(wildcard interp/*.cxx)) $(DICT)
 HEADERS := $(filter-out $(LINKDEF), $(wildcard *.h)   $(wildcard sfset/*.h)   $(wildcard interp/*.h)    $(wildcard interp/*.ipp)) $(LINKDEF)
+ifdef EXCLUDE_DELPHES
+	SOURCES := $(filter-out AnalysisDelphes.cxx, $(SOURCES))
+	HEADERS := $(filter-out AnalysisDelphes.h,   $(HEADERS))
+endif
 
 #-----------------------------------------------
 


### PR DESCRIPTION
This allows for `libSidis-eic` builds without Delphes dependence, which
will significantly reduce the size of build artifacts, and hopefully
speed up workflows a bit more.