### PR TITLE
fix:  macros do not `#define INCLUDE_DELPHES`; switch to `#ifndef EXCLUDE_DELPHES`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ env:
   ebeam_en: 10
   pbeam_en: 100
   cross_ang: -25
+  root: root -b -q
+  root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 
 jobs:
 
@@ -210,7 +212,7 @@ jobs:
             echo "[CI] cat delphes.config"
             cat delphes.config
             echo "[CI] ANALYSIS MACRO"
-            root -b -q 'macro/ci/analysis_${{matrix.aname}}.C("delphes.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fastsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
+            ${{env.root}} 'macro/ci/analysis_${{matrix.aname}}.C("delphes.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fastsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
       - uses: actions/upload-artifact@v3
         with:
           name: root_analysis_fastsim_${{matrix.aname}}_${{matrix.recon}}
@@ -254,7 +256,7 @@ jobs:
             echo "[CI] cat s3files.config"
             cat s3files.config
             echo "[CI] ANALYSIS MACRO"
-            root -b -q macro/ci/define_exclude_delphes.C 'macro/ci/analysis_${{matrix.aname}}.C("s3files.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fullsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
+            ${{env.root_no_delphes}} 'macro/ci/analysis_${{matrix.aname}}.C("s3files.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fullsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
       - uses: actions/upload-artifact@v3
         with:
           name: root_analysis_fullsim_${{matrix.aname}}_${{matrix.recon}}
@@ -323,7 +325,7 @@ jobs:
             echo "[CI] POSTPROCESS MACRO"
             ls out
             mv -v out/${{matrix.mode}}.{${{matrix.aname}},${{matrix.pname}}}.${{matrix.recon}}.root # rename aname -> pname
-            root -b -q 'macro/ci/${{matrix.pmacro}}("out/${{matrix.mode}}.${{matrix.pname}}.${{matrix.recon}}.root")'
+            ${{env.root_no_delphes}} 'macro/ci/${{matrix.pmacro}}("out/${{matrix.mode}}.${{matrix.pname}}.${{matrix.recon}}.root")'
             rm -v out/${{matrix.mode}}.${{matrix.pname}}.${{matrix.recon}}.root # rm analysis_root artifact
       - uses: actions/upload-artifact@v3
         with:
@@ -396,7 +398,7 @@ jobs:
             ls out
             mv -v out/fastsim.{${{matrix.aname}},${{matrix.pname}}}.${{matrix.recon}}.root # rename aname -> pname
             mv -v out/fullsim.{${{matrix.aname}},${{matrix.pname}}}.${{matrix.recon}}.root # rename aname -> pname
-            root -b -q 'macro/ci/comparator.C("out/fastsim.${{matrix.pname}}.${{matrix.recon}}.root","out/fullsim.${{matrix.pname}}.${{matrix.recon}}.root","out/fastfull.${{matrix.pname}}.${{matrix.recon}}","${{matrix.xvar}}","${{matrix.yvar}}")'
+            ${{env.root_no_delphes}} 'macro/ci/comparator.C("out/fastsim.${{matrix.pname}}.${{matrix.recon}}.root","out/fullsim.${{matrix.pname}}.${{matrix.recon}}.root","out/fastfull.${{matrix.pname}}.${{matrix.recon}}","${{matrix.xvar}}","${{matrix.yvar}}")'
             rm -v out/fastsim.${{matrix.pname}}.${{matrix.recon}}.root # rm analysis_root artifact
             rm -v out/fullsim.${{matrix.pname}}.${{matrix.recon}}.root # rm analysis_root artifact
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
             echo "[CI] cat delphes.config"
             cat delphes.config
             echo "[CI] ANALYSIS MACRO"
-            root -b -q macro/ci/include_delphes.C 'macro/ci/analysis_${{matrix.aname}}.C("delphes.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fastsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
+            root -b -q 'macro/ci/analysis_${{matrix.aname}}.C("delphes.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fastsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
       - uses: actions/upload-artifact@v3
         with:
           name: root_analysis_fastsim_${{matrix.aname}}_${{matrix.recon}}
@@ -254,7 +254,7 @@ jobs:
             echo "[CI] cat s3files.config"
             cat s3files.config
             echo "[CI] ANALYSIS MACRO"
-            root -b -q 'macro/ci/analysis_${{matrix.aname}}.C("s3files.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fullsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
+            root -b -q macro/ci/define_exclude_delphes.C 'macro/ci/analysis_${{matrix.aname}}.C("s3files.config",${{env.ebeam_en}},${{env.pbeam_en}},${{env.cross_ang}},"fullsim.${{matrix.aname}}.${{matrix.recon}}","${{matrix.recon}}")'
       - uses: actions/upload-artifact@v3
         with:
           name: root_analysis_fullsim_${{matrix.aname}}_${{matrix.recon}}

--- a/config.mk
+++ b/config.mk
@@ -17,10 +17,11 @@ LIBS = $(shell root-config --glibs)
 #LIBS += -lMinuit -lRooFitCore -lRooFit -lRooStats -lProof -lMathMore
 
 # DELPHES
-ifndef EXCLUDE_DELPHES
+ifdef EXCLUDE_DELPHES
+	FLAGS += -DEXCLUDE_DELPHES
+else
 	DEPS += -I${DELPHES_HOME} -I${DELPHES_HOME}/external
 	LIBS += -L${DELPHES_HOME} -lDelphes
-	FLAGS += -DINCLUDE_DELPHES
 endif
 
 # DELPHES plugin: Fastjet Centauro

--- a/config.mk
+++ b/config.mk
@@ -40,5 +40,5 @@ LIBS += -L${ADAGE_HOME}/lib -lAdage
 
 # SIDIS-EIC
 ifndef SIDIS_EIC_HOME
-	$(error "ERROR: run 'source environ.sh' before building")
+$(error "ERROR: run 'source environ.sh' before building")
 endif

--- a/macro/ci/analysis_p_eta.C
+++ b/macro/ci/analysis_p_eta.C
@@ -14,7 +14,7 @@ void analysis_p_eta(
   Analysis *A;
   if(outfilePrefix.Contains("fullsim"))
        A = new AnalysisAthena(  infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
   else A = new AnalysisDelphes( infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
 #endif
 

--- a/macro/ci/analysis_x_q2.C
+++ b/macro/ci/analysis_x_q2.C
@@ -18,7 +18,7 @@ void analysis_x_q2(
   Analysis *A;
   if(outfilePrefix.Contains("fullsim"))
        A = new AnalysisAthena(  infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
   else A = new AnalysisDelphes( infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
 #endif
 

--- a/macro/ci/analysis_yRatio.C
+++ b/macro/ci/analysis_yRatio.C
@@ -14,7 +14,7 @@ void analysis_yRatio(
   Analysis *A;
   if(outfilePrefix.Contains("fullsim"))
        A = new AnalysisAthena(  infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
   else A = new AnalysisDelphes( infiles, eleBeamEn, ionBeamEn, crossingAngle, outfilePrefix );
 #endif
 

--- a/macro/ci/define_exclude_delphes.C
+++ b/macro/ci/define_exclude_delphes.C
@@ -1,0 +1,3 @@
+{
+#define EXCLUDE_DELPHES
+}

--- a/macro/ci/include_delphes.C
+++ b/macro/ci/include_delphes.C
@@ -1,3 +1,0 @@
-{
-#define INCLUDE_DELPHES
-}

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -71,7 +71,7 @@ Analysis::Analysis(
   PIDtoFinalState.insert({  2212, "pTrack"   });
 
   // jets
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
   // available variables for binning
   availableBinSchemes.insert({ "ptJet", "jet p_{T}" });
   availableBinSchemes.insert({ "zJet",  "jet z"     });
@@ -269,7 +269,7 @@ void Analysis::Prepare() {
   HD->SetBinSchemeValue("tSpin", [this](){ return (Double_t)kin->tSpin;         });
   HD->SetBinSchemeValue("lSpin", [this](){ return (Double_t)kin->lSpin;         });
   /* jets */
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
   HD->SetBinSchemeValue("ptJet", [this](){ return kin->pTjet;                   });
   HD->SetBinSchemeValue("zJet",  [this](){ return kin->zjet;                    });
 #endif
@@ -395,7 +395,7 @@ void Analysis::Prepare() {
         NBINS,-TMath::Pi(),TMath::Pi()
         );
     // -- jet kinematics
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
     HS->DefineHist1D("pT_jet","jet p_{T}","GeV", NBINS, 1e-2, 50);
     HS->DefineHist1D("mT_jet","jet m_{T}","GeV", NBINS, 1e-2, 20);
     HS->DefineHist1D("z_jet","jet z","", NBINS,0, 1);
@@ -651,7 +651,7 @@ void Analysis::FillHistosTracks() {
 
 
 // jets
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
 void Analysis::FillHistosJets() {
 
   // check which bins to fill

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -198,6 +198,7 @@ void Analysis::Prepare() {
           return;
         }
         entries[idx] = tree->GetEntries();
+        file->Close();
       }
     }
     if (!AddFile(fileNames, entries, xs, Q2min)) {

--- a/src/Analysis.h
+++ b/src/Analysis.h
@@ -96,7 +96,7 @@ class Analysis : public TNamed
 
     // FillHistos methods: fill histograms
     void FillHistosTracks();
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
     void FillHistosJets();
 #endif
 
@@ -135,7 +135,7 @@ class Analysis : public TNamed
     int pid;
     TString finalStateID;
     Double_t wTrack,wJet;
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
     fastjet::PseudoJet jet;
 #endif
 

--- a/src/Kinematics.cxx
+++ b/src/Kinematics.cxx
@@ -470,7 +470,7 @@ void Kinematics::ResetHFS() {
 
 
 // DELPHES-only methods //////////////////////////////////////////////////////
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
 // calculates reconstructed hadronic final state variables from DELPHES tree branches
 // expects 'vecElectron' set
 // - calculates `sigmah`, `Pxh`, and `Pyh` in the lab and head-on frames
@@ -907,7 +907,7 @@ void Kinematics::CalculateBreitJetKinematics(fastjet::PseudoJet jet){
 
 };
 #endif // ifdef INCLUDE_CENTAURO
-#endif // ifdef INCLUDE_DELPHES
+#endif // ifndef EXCLUDE_DELPHES
 // end DELPHES-only methods //////////////////////////////////////////////////////
 
 

--- a/src/Kinematics.h
+++ b/src/Kinematics.h
@@ -23,7 +23,7 @@
 #include "TRandomGen.h"
 
 // Delphes
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
 #include "classes/DelphesClasses.h"
 #include "fastjet/ClusterSequence.hh"
 #ifdef INCLUDE_CENTAURO
@@ -53,7 +53,7 @@ class Kinematics : public TObject
 
 
     // DELPHES-specific methods //////////////////////////
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
 
     // hadronic final state (HFS)
     void GetHFS(
@@ -90,7 +90,7 @@ class Kinematics : public TObject
         );
     void CalculateBreitJetKinematics(fastjet::PseudoJet jet);
 #endif // ifdef INCLUDE_CENTAURO
-#endif // ifdef INCLUDE_DELPHES
+#endif // ifndef EXCLUDE_DELPHES
     // end DELPHES-specific methods //////////////////////////
 
 
@@ -128,7 +128,7 @@ class Kinematics : public TObject
     TLorentzVector vecElectron, vecW, vecQ;
     TLorentzVector vecHadron;
 
-#ifdef INCLUDE_DELPHES
+#ifndef EXCLUDE_DELPHES
     // jet objects
     std::vector<fastjet::PseudoJet> jetsRec, jetsTrue;
     std::vector<fastjet::PseudoJet> breitJetsRec, breitJetsTrue;

--- a/src/LinkDef.h
+++ b/src/LinkDef.h
@@ -25,7 +25,9 @@
 #pragma link C++ class Analysis+;
 #pragma link C++ class AnalysisAthena+;
 #pragma link C++ class AnalysisEcce+;
+#ifndef EXCLUDE_DELPHES
 #pragma link C++ class AnalysisDelphes+;
+#endif
 
 // postprocessing
 #pragma link C++ class PostProcessor+;

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,7 @@
 include ../config.mk
 
 SIDIS_EIC = Sidis-eic
+ROOTCLING = rootcling
 
 # targets
 PREFIX  := ${SIDIS_EIC_HOME}/lib
@@ -15,6 +16,7 @@ HEADERS := $(filter-out $(LINKDEF), $(wildcard *.h)   $(wildcard sfset/*.h)   $(
 ifdef EXCLUDE_DELPHES
 	SOURCES := $(filter-out AnalysisDelphes.cxx, $(SOURCES))
 	HEADERS := $(filter-out AnalysisDelphes.h,   $(HEADERS))
+	ROOTCLING += -D=EXCLUDE_DELPHES
 endif
 
 #-----------------------------------------------
@@ -27,7 +29,7 @@ $(PREFIX)/$(LIB): $(DICT) $(HEADERS) $(SOURCES)
 $(DICT): $(HEADERS)
 	@echo ">>>>> generate $(SIDIS_EIC) dictionary"
 	@echo "      $@"
-	@rootcling -f $@ $(DEPS) $^
+	$(ROOTCLING) -f $@ $(DEPS) $^
 	@mkdir -p $(PREFIX)
 	@mv $(PCM) $(PREFIX)/
 


### PR DESCRIPTION
ROOT macros typically do not `#define INCLUDE_DELPHES`, except those for CI; therefore `#ifdef INCLUDE_DELPHES` is false by default. This explains why sporadic crashes of #174 were occurring locally, but not in CI workflows. This PR switches to using `#ifndef EXCLUDE_DELPHES`, since that will be true by default.