### PR TITLE
feat: control what is included in the output data structures

### DIFF
--- a/macro/depolarization/analysis_depolarization.C
+++ b/macro/depolarization/analysis_depolarization.C
@@ -19,6 +19,7 @@ void analysis_depolarization(
 
   A->SetReconMethod("Ele"); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
+  A->includeOutputSet["depolarization"] = true; // include depolarization plots
 
   /// SIDIS common cuts
   A->AddBinScheme("w");     A->BinScheme("w")->BuildBin("Min",3.0);         // W > 3 GeV

--- a/src/Analysis.h
+++ b/src/Analysis.h
@@ -60,6 +60,8 @@ class Analysis : public TNamed
     Bool_t useBreitJets; // if true, use Breit jets, if using finalState `jets` (requires centauro)
     // set kinematics reconstruction method; see constructor for available methods
     void SetReconMethod(TString reconMethod_) { reconMethod=reconMethod_; }; 
+    // choose which output sets to include
+    std::map<TString,Bool_t> includeOutputSet;
 
     // add a group of files to the analysis, where all of these files have a
     // common cross section `xs`, and Q2 range `Q2min` to `Q2max`

--- a/src/AnalysisAthena.cxx
+++ b/src/AnalysisAthena.cxx
@@ -264,13 +264,15 @@ void AnalysisAthena::Execute()
       wTrack = Q2weightFactor * weight->GetWeight(*kinTrue);
       wTrackTotal += wTrack;
 
-      // fill track histograms in activated bins
-      FillHistosTracks();
+      if(includeOutputSet["1h"]) {
+        // fill track histograms in activated bins
+        FillHistosTracks();
 
-      // fill simple tree
-      // - not binned
-      // - `IsActiveEvent()` is only true if at least one bin gets filled for this track
-      if( writeSimpleTree && HD->IsActiveEvent() ) ST->FillTree(wTrack);
+        // fill simple tree
+        // - not binned
+        // - `IsActiveEvent()` is only true if at least one bin gets filled for this track
+        if( writeSimpleTree && HD->IsActiveEvent() ) ST->FillTree(wTrack);
+      }
 
     }//hadron loop
 

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -214,13 +214,15 @@ void AnalysisDelphes::Execute() {
       wTrack = Q2weightFactor * weight->GetWeight(*kinTrue);
       wTrackTotal += wTrack;
 
-      // fill track histograms in activated bins
-      FillHistosTracks();
+      if(includeOutputSet["1h"]) {
+        // fill track histograms in activated bins
+        FillHistosTracks();
 
-      // fill simple tree
-      // - not binned
-      // - `IsActiveEvent()` is only true if at least one bin gets filled for this track
-      if( writeSimpleTree && HD->IsActiveEvent() ) ST->FillTree(wTrack);
+        // fill simple tree
+        // - not binned
+        // - `IsActiveEvent()` is only true if at least one bin gets filled for this track
+        if( writeSimpleTree && HD->IsActiveEvent() ) ST->FillTree(wTrack);
+      }
 
       // tests
       //kin->ValidateHeadOnFrame();
@@ -230,7 +232,9 @@ void AnalysisDelphes::Execute() {
 
     // jet loop - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     finalStateID = "jet";
-    if(activeFinalStates.find(finalStateID)!=activeFinalStates.end()) {
+    // FIXME: probably don't need both a `finalStateID` and `includeOutputSet` to control whether
+    //        we do anything with jets or not
+    if(activeFinalStates.find(finalStateID)!=activeFinalStates.end() && includeOutputSet["jets"]) {
 
 #ifdef INCLUDE_CENTAURO
       if(useBreitJets) kin->GetBreitFrameJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);

--- a/src/AnalysisEcce.cxx
+++ b/src/AnalysisEcce.cxx
@@ -350,13 +350,15 @@ void AnalysisEcce::Execute()
       wTrack = Q2weightFactor * weight->GetWeight(*kinTrue);
       wTrackTotal += wTrack;
 
-      // fill track histograms in activated bins
-      FillHistosTracks();
+      if(includeOutputSet["1h"]) {
+        // fill track histograms in activated bins
+        FillHistosTracks();
 
-      // fill simple tree
-      // - not binned
-      // - `IsActiveEvent()` is only true if at least one bin gets filled for this track
-      if( writeSimpleTree && HD->IsActiveEvent() ) ST->FillTree(wTrack);
+        // fill simple tree
+        // - not binned
+        // - `IsActiveEvent()` is only true if at least one bin gets filled for this track
+        if( writeSimpleTree && HD->IsActiveEvent() ) ST->FillTree(wTrack);
+      }
 
     }//hadron loop
 

--- a/src/Histos.cxx
+++ b/src/Histos.cxx
@@ -198,7 +198,7 @@ TH1 *Histos::Hist(TString histName, Bool_t silence) {
   catch(const std::out_of_range &ex) {
     if(!silence)
       cerr << "ERROR: histMap does not have " 
-           << histName << "histogram" << endl;
+           << histName << " histogram" << endl;
     return nullptr;
   };
   return retHist;
@@ -210,7 +210,7 @@ Hist4D *Histos::Hist4(TString histName, Bool_t silence) {
   catch(const std::out_of_range &ex) {
     if(!silence)
       cerr << "ERROR: hist4Map does not have " 
-           << histName << "histogram" << endl;
+           << histName << " histogram" << endl;
     return nullptr;
   };
   return retHist;

--- a/src/Histos.h
+++ b/src/Histos.h
@@ -130,6 +130,23 @@ class Histos : public TNamed
       ofile->cd("/");
     };
 
+    // fill a histogram, iff it is defined
+    template <typename... VALS> void FillHist1D(TString histName, VALS... values) {
+      auto hist = Hist(histName,true);
+      if(hist) hist->Fill(values...);
+    }
+    template <typename... VALS> void FillHist2D(TString histName, VALS... values) {
+      auto hist = Hist(histName,true);
+      if(hist) dynamic_cast<TH2*>(hist)->Fill(values...);
+    }
+    template <typename... VALS> void FillHist3D(TString histName, VALS... values) {
+      auto hist = Hist(histName,true);
+      if(hist) dynamic_cast<TH3*>(hist)->Fill(values...);
+    }
+    template <typename... VALS> void FillHist4D(TString histName, VALS... values) {
+      auto hist = Hist4(histName,true);
+      if(hist) hist->Fill(values...);
+    }
 
   private:
     TString setname,settitle;

--- a/tutorial/analysis_dd4hep.C
+++ b/tutorial/analysis_dd4hep.C
@@ -29,6 +29,14 @@ void analysis_dd4hep(
   // - see `Analysis` constructor for methods (or other tutorials)
   A->SetReconMethod("Ele");
 
+  // decide which output sets to include ===================
+  // - by default, only single-hadron data are included in the output
+  // - see `src/Analysis.cxx` for all available settings
+  //A->includeOutputSet["jets"] = true;
+  //A->includeOutputSet["1h"] = false;
+  //A->includeOutputSet["inclusive"] = false;
+  //A->includeOutputSet["depolarization"] = true;
+
   A->AddFinalState("pipTrack");
   //A->AddFinalState("pimTrack");
   //A->AddFinalState("KpTrack");

--- a/tutorial/analysis_eventEvaluator.C
+++ b/tutorial/analysis_eventEvaluator.C
@@ -29,6 +29,14 @@ void analysis_eventEvaluator(
   // - see `Analysis` constructor for methods (or other tutorials)
   A->SetReconMethod("Ele");
 
+  // decide which output sets to include ===================
+  // - by default, only single-hadron data are included in the output
+  // - see `src/Analysis.cxx` for all available settings
+  //A->includeOutputSet["jets"] = true;
+  //A->includeOutputSet["1h"] = false;
+  //A->includeOutputSet["inclusive"] = false;
+  //A->includeOutputSet["depolarization"] = true;
+
   A->AddFinalState("pipTrack");
   //A->AddFinalState("pimTrack");
   //A->AddFinalState("KpTrack");

--- a/tutorial/analysis_template.C
+++ b/tutorial/analysis_template.C
@@ -23,6 +23,15 @@ void analysis_template(
   // - see `Analysis` constructor for methods
   A->SetReconMethod("Ele");
 
+  // decide which output sets to include ===================
+  // - by default, only single-hadron data are included
+  // - to look at jets, we need to make sure they are included
+  A->includeOutputSet["jets"] = true;
+  // - additional example settings; see `src/Analysis.cxx` for more
+  //A->includeOutputSet["1h"] = false;
+  //A->includeOutputSet["inclusive"] = false;
+  //A->includeOutputSet["depolarization"] = true;
+
   // define cuts ====================================
   // - cuts are defined the same way as bins are defined; be mindful
   //   of what bins you are defining vs. what cuts you are defining.
@@ -41,8 +50,9 @@ void analysis_template(
   /* do nothing -> single bin histograms */
 
   // final states =========================================
-  // - define final states; if you define none, default sets will
-  //   be defined
+  // - define final states; if you define none, default sets will be defined
+  // - although jets are included in `includeOutputSet`, we still need to
+  //   included them in the list of final states here
   A->AddFinalState("pipTrack");
   //A->AddFinalState("pimTrack");
   //A->AddFinalState("KpTrack");


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Add `includeOutputSet` settings in `Analysis`, to control what to include in the output. This will allow us to turn on/off large sets of plots or tree branches, along with certain parts of the `Analysis` subclass event loops. For example, we can now implement a dihadron analysis which will only run if a macro tells it to.




### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [x] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
No