### PR TITLE
ci: test `hepmc` files from Ralf through Delphes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
             s3tools/add-host.sh
             echo "[CI] generate list of HEPMC files"
             s3tools/generate-hepmc-list.sh ${{env.ebeam_en}}x${{env.pbeam_en}} ${{matrix.minq2}} 1 | tee hepmc.list
+          if [ $(cat hepmc.list|wc -l) -eq 0 ]; then echo "WARNING: NO HEPMC FILES FOUND; skipping this job..."; exit 0; fi
             echo "[CI] download HEPMC files"
             # while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
             while read hepmc; do mc head --lines 3000000 $hepmc > datagen/$(basename $hepmc); done < hepmc.list # truncate the hepmc file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 10
-  pbeam_en: 100
+  ebeam_en: 18
+  pbeam_en: 275
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,15 +109,15 @@ jobs:
             echo "[CI] download HEPMC files"
             # while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
             while read hepmc; do mc head --lines 3000000 $hepmc > datagen/$(basename $hepmc); done < hepmc.list # truncate the hepmc file
-            for hepmc in datagen/*.hepmc; do s3tools/trim_hepmc.rb $hepmc $hepmc.trimmed; done # remove the final, partial event
-            for hepmc in datagen/*.hepmc; do mv -v $hepmc.trimmed $hepmc; done
+            for hepmc in $(ls datagen/*.hepmc); do s3tools/trim_hepmc.rb $hepmc $hepmc.trimmed; done # remove the final, partial event
+            for hepmc in $(ls datagen/*.hepmc); do mv -v $hepmc.trimmed $hepmc; done
             echo "====="
             ls -lh datagen
             echo "[CI] install delphes"
             deps/install_delphes.sh
             echo "[CI] RUN DELPHES"
             chmod u+x deps/delphes/DelphesHepMC3
-            for hepmc in datagen/*.hepmc; do deps/run_delphes.sh $hepmc; done
+            for hepmc in $(ls datagen/*.hepmc); do deps/run_delphes.sh $hepmc; done
             echo "====="
             ls -lh datarec
             echo "[CI] make config file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 18
-  pbeam_en: 275
+  ebeam_en: 5
+  pbeam_en: 41
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
             s3tools/add-host.sh
             echo "[CI] generate list of HEPMC files"
             s3tools/generate-hepmc-list.sh ${{env.ebeam_en}}x${{env.pbeam_en}} ${{matrix.minq2}} 1 | tee hepmc.list
-          if [ $(cat hepmc.list|wc -l) -eq 0 ]; then echo "WARNING: NO HEPMC FILES FOUND; skipping this job..."; exit 0; fi
+            if [ $(cat hepmc.list|wc -l) -eq 0 ]; then echo "WARNING: NO HEPMC FILES FOUND; skipping this job..."; exit 0; fi
             echo "[CI] download HEPMC files"
             # while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
             while read hepmc; do mc head --lines 3000000 $hepmc > datagen/$(basename $hepmc); done < hepmc.list # truncate the hepmc file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,9 +105,12 @@ jobs:
             echo "[CI] add S3 host"
             s3tools/add-host.sh
             echo "[CI] generate list of HEPMC files"
-            s3tools/generate-hepmc-list.sh ${{env.ebeam_en}}x${{env.pbeam_en}} ${{matrix.minq2}} 6 | tee hepmc.list
+            s3tools/generate-hepmc-list.sh ${{env.ebeam_en}}x${{env.pbeam_en}} ${{matrix.minq2}} 1 | tee hepmc.list
             echo "[CI] download HEPMC files"
-            while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
+            # while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
+            while read hepmc; do mc head --lines 3000000 $hepmc > datagen/$(basename $hepmc); done < hepmc.list # truncate the hepmc file
+            for hepmc in datagen/*.hepmc; do s3tools/trim_hepmc.rb $hepmc hepmc.trimmed; done # remove the final, partial event
+            for hepmc in datagen/*.hepmc; do mv -v $hepmc.trimmed $hepmc; done
             echo "====="
             ls -lh datagen
             echo "[CI] install delphes"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
             deps/install_delphes.sh
             echo "[CI] RUN DELPHES"
             chmod u+x deps/delphes/DelphesHepMC3
-            for hepmc in datagen/*.hepmc.gz; do deps/run_delphes.sh $hepmc; done
+            for hepmc in datagen/*.hepmc; do deps/run_delphes.sh $hepmc; done
             echo "====="
             ls -lh datarec
             echo "[CI] make config file"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,7 @@ jobs:
             s3tools/add-host.sh
             echo "[CI] generate list of HEPMC files"
             s3tools/generate-hepmc-list.sh ${{env.ebeam_en}}x${{env.pbeam_en}} ${{matrix.minq2}} 1 | tee hepmc.list
-            if [ $(cat hepmc.list|wc -l) -eq 0 ]; then echo "WARNING: NO HEPMC FILES FOUND; skipping this job..."; exit 0; fi
+            if [ $(cat hepmc.list|wc -l) -eq 0 ]; then echo "WARNING: NO HEPMC FILES FOUND; skipping this job..."; touch delphes.config.list; exit 0; fi
             echo "[CI] download HEPMC files"
             # while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
             while read hepmc; do mc head --lines 3000000 $hepmc > datagen/$(basename $hepmc); done < hepmc.list # truncate the hepmc file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
             echo "[CI] download HEPMC files"
             # while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
             while read hepmc; do mc head --lines 3000000 $hepmc > datagen/$(basename $hepmc); done < hepmc.list # truncate the hepmc file
-            for hepmc in datagen/*.hepmc; do s3tools/trim_hepmc.rb $hepmc hepmc.trimmed; done # remove the final, partial event
+            for hepmc in datagen/*.hepmc; do s3tools/trim_hepmc.rb $hepmc $hepmc.trimmed; done # remove the final, partial event
             for hepmc in datagen/*.hepmc; do mv -v $hepmc.trimmed $hepmc; done
             echo "====="
             ls -lh datagen

--- a/s3tools/generate-hepmc-list.sh
+++ b/s3tools/generate-hepmc-list.sh
@@ -17,9 +17,19 @@ minQ2=$2
 limit=0
 if [ $# -ge 3 ]; then limit=$3; fi
 
-evgenDir="S3/eictest/ATHENA/EVGEN/DIS/NC/$energy/minQ2=$minQ2"
+### ATHENA Pythia8 files
+# evgenDir="S3/eictest/ATHENA/EVGEN/DIS/NC/$energy/minQ2=$minQ2"
+# if [ $limit -gt 0 ]; then
+#   mc ls $evgenDir | grep -E 'hepmc.gz$' | grep -v GiB | grep vtxfix | head -n$limit | sed "s;^.* ;$evgenDir/;g"
+# else
+#   mc ls $evgenDir | grep -E 'hepmc.gz$' | grep -v GiB | grep vtxfix | sed "s;^.* ;$evgenDir/;g"
+# fi
+
+### EPIC
+evgenDir="S3/eictest/EPIC/EVGEN/DIS/NC/$energy/noradcor"
+# evgenDir="S3/eictest/EPIC/EVGEN/DIS/NC/$energy/radcor"
 if [ $limit -gt 0 ]; then
-  mc ls $evgenDir | grep -E 'hepmc.gz$' | grep -v GiB | grep vtxfix | head -n$limit | sed "s;^.* ;$evgenDir/;g"
+  mc ls $evgenDir | grep "q2_${minQ2}_"| grep -E '\.hepmc$' | head -n$limit | sed "s;^.* ;$evgenDir/;g"
 else
-  mc ls $evgenDir | grep -E 'hepmc.gz$' | grep -v GiB | grep vtxfix | sed "s;^.* ;$evgenDir/;g"
+  mc ls $evgenDir | grep "q2_${minQ2}_"| grep -E '\.hepmc$'                 | sed "s;^.* ;$evgenDir/;g"
 fi

--- a/s3tools/trim_hepmc.rb
+++ b/s3tools/trim_hepmc.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+# remove any partial, final event from a HEPMC file
+# (not efficient, this is only used for CI tests)
+
+if ARGV.length<2
+  $stderr.puts "USAGE: #{$0} [hepmc file] [output file]"
+  exit 2
+end
+streamFile = ARGV[0]
+outFile    = ARGV[1]
+
+puts "TRIMMING #{streamFile}"
+
+out = File.open outFile, 'w'
+buffer = []
+File.readlines(streamFile).each do |line|
+  if line.match? /^E /
+    buffer.each do |output| out.puts output end
+    buffer.clear
+  end
+  buffer << line
+end
+out.close
+
+puts " -> #{outFile}"

--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -239,7 +239,10 @@ void Analysis::Prepare() {
         fileNames.clear();
       }
       // parse setting value(s)
-      if      (bufferKey==":eleBeamEn")         eleBeamEn         = std::stod(bufferVal);
+      if(debugParser) fmt::print("  parse as setting: bufferKey='{}' bufferVal='{}'\n",bufferKey,bufferVal);
+      if(bufferVal=="")
+        fmt::print(stderr,"ERROR: setting '{}' has no associated value\n",bufferKey);
+      else if (bufferKey==":eleBeamEn")         eleBeamEn         = std::stod(bufferVal);
       else if (bufferKey==":ionBeamEn")         ionBeamEn         = std::stod(bufferVal);
       else if (bufferKey==":crossingAngle")     crossingAngle     = std::stod(bufferVal);
       else if (bufferKey==":totalCrossSection") totalCrossSection = std::stod(bufferVal);
@@ -247,7 +250,7 @@ void Analysis::Prepare() {
       else if (bufferKey==":q2max")             Q2max             = std::stod(bufferVal);
       else if (bufferKey==":crossSection")      xsec              = std::stod(bufferVal);
       else
-        fmt::print(stderr,"WARNING: unkown setting \"{}\"\n",bufferKey);
+        fmt::print(stderr,"ERROR: unkown setting \"{}\"\n",bufferKey);
       if(debugParser) fmt::print("  setting:  \"{}\" = \"{}\"\n",bufferKey,bufferVal);
     }
     else if (parseAs==kRootFile) {


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Test new `hepmc` files from Ralf. Since these files are very large, we truncate them in the workflow config with `mc head`, so we don't overload runners.

The CI runs these files through `Delphes`, using the ATHENA card (we don't have an EPIC card yet). Thus in the `_FULL_RESULTS` artifact, the `Delphes` distributions (black, grey filled) should compare well with the ATHENA `DeathValley` data (red dashed).

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: @rseidl-rcf 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No

### Does this PR change default behavior?
It will change our Delphes HEPMC source under CI tests