### PR TITLE
fix: create `jet` final state when included in output

### DIFF
--- a/macro/analysis_PvsEta.C
+++ b/macro/analysis_PvsEta.C
@@ -19,7 +19,6 @@ void analysis_PvsEta(
   A->SetReconMethod("Ele"); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
   A->AddFinalState("KpTrack"); // kaon final state
-  //A->AddFinalState("jet"); // jets
 
 
   // define cuts ====================================

--- a/macro/analysis_coverage.C
+++ b/macro/analysis_coverage.C
@@ -20,7 +20,6 @@ void analysis_coverage(
   A->AddFinalState("pipTrack"); // pion final state
   A->AddFinalState("KpTrack"); // kaon final state
   A->AddFinalState("pTrack"); // proton final state                                                                                                                         
-  //A->AddFinalState("jet"); // jets
 
 
   // define cuts ====================================

--- a/macro/analysis_purity.C
+++ b/macro/analysis_purity.C
@@ -19,7 +19,6 @@ void analysis_purity(
   A->SetReconMethod(methodname); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
   //A->AddFinalState("KpTrack"); // kaon final state
-  //A->AddFinalState("jet"); // jets
 
 
   // define cuts ====================================

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -153,7 +153,8 @@ void AnalysisDelphes::Execute() {
 
     // get vector of jets
     // TODO: should this have an option for clustering method?
-    kin->GetJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);
+    if(includeOutputSet["jets"])
+      kin->GetJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);
    
     // track loop - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     itTrack.Reset();
@@ -228,10 +229,8 @@ void AnalysisDelphes::Execute() {
 
 
     // jet loop - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    finalStateID = "jet";
-    // FIXME: probably don't need both a `finalStateID` and `includeOutputSet` to control whether
-    //        we do anything with jets or not
-    if(activeFinalStates.find(finalStateID)!=activeFinalStates.end() && includeOutputSet["jets"]) {
+    if(includeOutputSet["jets"]) {
+      finalStateID = "jet";
 
 #ifdef INCLUDE_CENTAURO
       if(useBreitJets) kin->GetBreitFrameJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);

--- a/tutorial/analysis_coverage.C
+++ b/tutorial/analysis_coverage.C
@@ -14,7 +14,6 @@ void analysis_coverage(
   A->SetReconMethod("Ele"); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
   //A->AddFinalState("KpTrack"); // kaon final state
-  //A->AddFinalState("jet"); // jets
 
 
   // define cuts ====================================

--- a/tutorial/analysis_dd4hep.C
+++ b/tutorial/analysis_dd4hep.C
@@ -41,7 +41,6 @@ void analysis_dd4hep(
   //A->AddFinalState("pimTrack");
   //A->AddFinalState("KpTrack");
   //A->AddFinalState("KmTrack");
-  //A->AddFinalState("jet"); // (TODO)
 
 
   // define cuts ====================================

--- a/tutorial/analysis_epic.C
+++ b/tutorial/analysis_epic.C
@@ -55,7 +55,6 @@ void analysis_epic(
   // A->AddFinalState("pimTrack");
   // A->AddFinalState("KpTrack");
   // A->AddFinalState("KmTrack");
-  // A->AddFinalState("jet"); // (TODO)
 
 
   // define cuts ====================================

--- a/tutorial/analysis_eventEvaluator.C
+++ b/tutorial/analysis_eventEvaluator.C
@@ -41,7 +41,6 @@ void analysis_eventEvaluator(
   //A->AddFinalState("pimTrack");
   //A->AddFinalState("KpTrack");
   //A->AddFinalState("KmTrack");
-  //A->AddFinalState("jet"); // (TODO)
 
 
   // define cuts ====================================

--- a/tutorial/analysis_qbins.C
+++ b/tutorial/analysis_qbins.C
@@ -13,7 +13,6 @@ void analysis_qbins(
   A->SetReconMethod("Ele"); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
   //A->AddFinalState("KpTrack"); // kaon final state
-  //A->AddFinalState("jet"); // jets
 
 
   // define cuts ====================================

--- a/tutorial/analysis_template.C
+++ b/tutorial/analysis_template.C
@@ -25,7 +25,7 @@ void analysis_template(
 
   // decide which output sets to include ===================
   // - by default, only single-hadron data are included
-  // - to look at jets, we need to make sure they are included
+  // - to include jets, we just need to make sure they are included in the output
   A->includeOutputSet["jets"] = true;
   // - additional example settings; see `src/Analysis.cxx` for more
   //A->includeOutputSet["1h"] = false;
@@ -39,6 +39,8 @@ void analysis_template(
   //   Q2 bins below, you may be creating more bins than you actually
   //   need, since the Q2 minimum cut actually defines another bin;
   //   in this case, your Q2 bins effectively define a Q2 minimum.
+  // - the cuts listed here are for single-hadrons only; similar cuts can be
+  //   defined for jets
   A->AddBinScheme("w");  A->BinScheme("w")->BuildBin("Min",3.0); // W > 3 GeV
   A->AddBinScheme("y");  A->BinScheme("y")->BuildBin("Range",0.01,0.95); // 0.01 < y < 0.95
   A->AddBinScheme("z");  A->BinScheme("z")->BuildBin("Range",0.2,0.9); // 0.2 < z < 0.9
@@ -50,14 +52,12 @@ void analysis_template(
   /* do nothing -> single bin histograms */
 
   // final states =========================================
-  // - define final states; if you define none, default sets will be defined
-  // - although jets are included in `includeOutputSet`, we still need to
-  //   included them in the list of final states here
+  // - define single-hadron final states; if you define none, default sets will be defined
+  // - note: if you included jets above, there will also be a final state for jets, automatically defined
   A->AddFinalState("pipTrack");
   //A->AddFinalState("pimTrack");
   //A->AddFinalState("KpTrack");
   //A->AddFinalState("KmTrack");
-  A->AddFinalState("jet");
 
   // perform the analysis ==================================
   A->Execute();

--- a/tutorial/analysis_xqbins.C
+++ b/tutorial/analysis_xqbins.C
@@ -16,7 +16,6 @@ void analysis_xqbins(
   A->SetReconMethod("Ele"); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
   //A->AddFinalState("KpTrack"); // kaon final state
-  //A->AddFinalState("jet"); // jets
 
 
   // define cuts ====================================

--- a/tutorial/analysis_yRatio.C
+++ b/tutorial/analysis_yRatio.C
@@ -14,7 +14,6 @@ void analysis_yRatio(
   A->SetReconMethod("Ele"); // set reconstruction method
   A->AddFinalState("pipTrack"); // pion final state
   //A->AddFinalState("KpTrack"); // kaon final state
-  //A->AddFinalState("jet"); // jets
 
 
   // define cuts ====================================


### PR DESCRIPTION
- this removes the need for the user to call `AddFinalState` for jets
- also renames jet variables, to group them together
