### PR TITLE
ci: test `radcor` files from Ralf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 18
-  pbeam_en: 275
+  ebeam_en: 5
+  pbeam_en: 41
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 env:
-  ebeam_en: 5
-  pbeam_en: 41
+  ebeam_en: 18
+  pbeam_en: 275
   root: root -b -q
   root_no_delphes: root -b -q macro/ci/define_exclude_delphes.C 
 
@@ -105,20 +105,20 @@ jobs:
             echo "[CI] add S3 host"
             s3tools/add-host.sh
             echo "[CI] generate list of HEPMC files"
-            s3tools/generate-hepmc-list.sh ${{env.ebeam_en}}x${{env.pbeam_en}} ${{matrix.minq2}} 1 | tee hepmc.list
+            s3tools/generate-hepmc-list.sh ${{env.ebeam_en}}x${{env.pbeam_en}} ${{matrix.minq2}} 2 | tee hepmc.list
             if [ $(cat hepmc.list|wc -l) -eq 0 ]; then echo "WARNING: NO HEPMC FILES FOUND; skipping this job..."; touch delphes.config.list; exit 0; fi
             echo "[CI] download HEPMC files"
-            # while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
-            while read hepmc; do mc head --lines 3000000 $hepmc > datagen/$(basename $hepmc); done < hepmc.list # truncate the hepmc file
-            for hepmc in $(ls datagen/*.hepmc); do s3tools/trim_hepmc.rb $hepmc $hepmc.trimmed; done # remove the final, partial event
-            for hepmc in $(ls datagen/*.hepmc); do mv -v $hepmc.trimmed $hepmc; done
+            while read hepmc; do mc cp $hepmc datagen/; done < hepmc.list
+            # while read hepmc; do mc head --lines 3000000 $hepmc > datagen/$(basename $hepmc); done < hepmc.list # truncate the hepmc file
+            # for hepmc in $(ls datagen/*.hepmc); do s3tools/trim_hepmc.rb $hepmc $hepmc.trimmed; done # remove the final, partial event
+            # for hepmc in $(ls datagen/*.hepmc); do mv -v $hepmc.trimmed $hepmc; done
             echo "====="
             ls -lh datagen
             echo "[CI] install delphes"
             deps/install_delphes.sh
             echo "[CI] RUN DELPHES"
             chmod u+x deps/delphes/DelphesHepMC3
-            for hepmc in $(ls datagen/*.hepmc); do deps/run_delphes.sh $hepmc; done
+            for hepmc in $(ls datagen/*.hepmc.gz); do deps/run_delphes.sh $hepmc; done
             echo "====="
             ls -lh datarec
             echo "[CI] make config file"

--- a/s3tools/generate-hepmc-list.sh
+++ b/s3tools/generate-hepmc-list.sh
@@ -26,10 +26,10 @@ if [ $# -ge 3 ]; then limit=$3; fi
 # fi
 
 ### EPIC
-evgenDir="S3/eictest/EPIC/EVGEN/DIS/NC/$energy/noradcor"
-# evgenDir="S3/eictest/EPIC/EVGEN/DIS/NC/$energy/radcor"
+# evgenDir="S3/eictest/EPIC/EVGEN/DIS/NC/$energy/noradcor"
+evgenDir="S3/eictest/EPIC/EVGEN/DIS/NC/$energy/radcor"
 if [ $limit -gt 0 ]; then
-  mc ls $evgenDir | grep "q2_${minQ2}_"| grep -E '\.hepmc$' | head -n$limit | sed "s;^.* ;$evgenDir/;g"
+  mc ls $evgenDir | grep "q2_${minQ2}_"| grep -E '\.hepmc.gz$' | head -n$limit | sed "s;^.* ;$evgenDir/;g"
 else
-  mc ls $evgenDir | grep "q2_${minQ2}_"| grep -E '\.hepmc$'                 | sed "s;^.* ;$evgenDir/;g"
+  mc ls $evgenDir | grep "q2_${minQ2}_"| grep -E '\.hepmc.gz$'                 | sed "s;^.* ;$evgenDir/;g"
 fi


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Testing for #194 

The S3 `hepmc.gz` files are large, so this test is going to be somewhat heavy on the CI.

### Resulting Plots:
- 5x41: https://github.com/eic/sidis-eic/suites/8942310179/artifacts/410418843
- 18x275: https://github.com/eic/sidis-eic/suites/8940862960/artifacts/410395584