### PR TITLE
fix: separate `FillHistos` methods for inclusive kinematics

### DIFF
--- a/src/Analysis.cxx
+++ b/src/Analysis.cxx
@@ -99,8 +99,9 @@ Analysis::Analysis(
   jetMin          = 1.0; // Minimum Jet pT
   jetMatchDR      = 0.5; // Delta R between true and reco jet to be considered matched
 
-  weight = new WeightsUniform();
-  weightJet = new WeightsUniform();
+  weightInclusive = new WeightsUniform();
+  weightTrack     = new WeightsUniform();
+  weightJet       = new WeightsUniform();
 
   // miscellaneous
   infiles.clear();
@@ -314,6 +315,13 @@ void Analysis::Prepare() {
     AddFinalState("jet");
   }
 #endif
+
+  // determine if only including `inclusive` output set
+  includeOutputSet.insert({ "inclusive_only",
+      includeOutputSet["inclusive"]
+      && !includeOutputSet["1h"]
+      && !includeOutputSet["jets"]
+      });
 
   // if there are no final states defined, default to definitions here:
   if(BinScheme("finalState")->GetNumBins()==0) {
@@ -544,8 +552,9 @@ void Analysis::Prepare() {
 
 
   // initialize total weights
-  wTrackTotal = 0.;
-  wJetTotal = 0.;
+  wInclusiveTotal = 0.;
+  wTrackTotal     = 0.;
+  wJetTotal       = 0.;
 };
 
 void Analysis::CalculateEventQ2Weights() {
@@ -649,11 +658,13 @@ void Analysis::Finish() {
   if(writeSimpleTree) ST->WriteTree();
   HD->Payload([this](Histos *H){ H->WriteHists(outFile); }); HD->ExecuteAndClearOps();
   HD->Payload([this](Histos *H){ H->Write(); }); HD->ExecuteAndClearOps();
-  std::vector<Double_t> vec_wTrackTotal { wTrackTotal };
-  std::vector<Double_t> vec_wJetTotal { wJetTotal };
+  std::vector<Double_t> vec_wInclusiveTotal { wInclusiveTotal };
+  std::vector<Double_t> vec_wTrackTotal     { wTrackTotal     };
+  std::vector<Double_t> vec_wJetTotal       { wJetTotal       };
   outFile->WriteObject(&Q2xsecs, "XsTotal");
-  outFile->WriteObject(&vec_wTrackTotal, "WeightTotal");
-  outFile->WriteObject(&vec_wJetTotal, "WeightJetTotal");
+  outFile->WriteObject(&vec_wInclusiveTotal, "WeightInclusiveTotal");
+  outFile->WriteObject(&vec_wTrackTotal,     "WeightTrackTotal");
+  outFile->WriteObject(&vec_wJetTotal,       "WeightJetTotal");
 
   // write binning schemes
   for(auto const &kv : binSchemes) {
@@ -718,41 +729,56 @@ void Analysis::AddFinalState(TString finalStateN) {
 // - checks which bins the track/jet/etc. falls in
 // - fills the histograms in the associated Histos objects
 //--------------------------------------------------------------------------
-// tracks (single particles)
-void Analysis::FillHistosTracks() {
 
+// fill histograms (called by other specific FillHistos* methods)
+void Analysis::FillHistos(std::function<void(Histos*)> fill_payload) {
   // check which bins to fill, and activate the ones for which all defined cuts pass
   // (activates their corresponding `HistosDAG` nodes)
   HD->CheckBins();
-
   // fill histograms, for activated bins only
-  HD->Payload([this](Histos *H){
+  HD->Payload(fill_payload);
+  // execute the payload
+  // - save time and don't call `ClearOps` (next loop will overwrite lambda)
+  // - called with `activeNodesOnly==true` since we only want to fill bins associated
+  //   with this track
+  HD->ExecuteOps(true);
+};
+
+// fill inclusive histograms
+void Analysis::FillHistosInclusive(Double_t wgt) {
+  auto fill_payload = [this,wgt] (Histos *H) {
+    H->FillHist2D("Q2vsX", kin->x,  kin->Q2, wgt);
+    H->FillHist1D("Q2",    kin->Q2, wgt);
+    H->FillHist1D("x",     kin->x,  wgt);
+    H->FillHist1D("W",     kin->W,  wgt);
+    H->FillHist1D("y",     kin->y,  wgt);
+  };
+  FillHistos(fill_payload);
+};
+
+// fill 1h (single-hadron) histograms
+void Analysis::FillHistos1h(Double_t wgt) {
+  auto fill_payload = [this,wgt] (Histos *H) {
     // Full phase space.
-    H->FillHist4D("full_xsec", kin->x, kin->Q2, kin->pT, kin->z, wTrack);
-    // DIS kinematics
-    H->FillHist2D("Q2vsX", kin->x,  kin->Q2, wTrack);
-    H->FillHist1D("Q2",    kin->Q2, wTrack);
-    H->FillHist1D("x",     kin->x,  wTrack);
-    H->FillHist1D("W",     kin->W,  wTrack);
-    H->FillHist1D("y",     kin->y,  wTrack);
+    H->FillHist4D("full_xsec", kin->x, kin->Q2, kin->pT, kin->z, wgt);
     // hadron 4-momentum
-    H->FillHist1D("pLab",   kin->pLab,   wTrack);
-    H->FillHist1D("pTlab",  kin->pTlab,  wTrack);
-    H->FillHist1D("etaLab", kin->etaLab, wTrack);
-    H->FillHist1D("phiLab", kin->phiLab, wTrack);
+    H->FillHist1D("pLab",   kin->pLab,   wgt);
+    H->FillHist1D("pTlab",  kin->pTlab,  wgt);
+    H->FillHist1D("etaLab", kin->etaLab, wgt);
+    H->FillHist1D("phiLab", kin->phiLab, wgt);
     // hadron kinematics
-    H->FillHist1D("z",  kin->z,  wTrack);
-    H->FillHist1D("pT", kin->pT, wTrack);
-    H->FillHist1D("qT", kin->qT, wTrack);
-    if(kin->Q2!=0) H->FillHist1D("qTq",kin->qT/TMath::Sqrt(kin->Q2),wTrack);
-    H->FillHist1D("mX",         kin->mX,   wTrack);
-    H->FillHist1D("phiH",       kin->phiH, wTrack);
-    H->FillHist1D("phiS",       kin->phiS, wTrack);
-    H->FillHist2D("phiHvsPhiS", kin->phiS, kin->phiH, wTrack);
-    H->FillHist1D("phiSivers",  Kinematics::AdjAngle(kin->phiH - kin->phiS), wTrack);
-    H->FillHist1D("phiCollins", Kinematics::AdjAngle(kin->phiH + kin->phiS), wTrack);
-    H->FillHist2D("etaVsP",       kin->pLab, kin->etaLab, wTrack); // TODO: lab-frame p, or some other frame?
-    H->FillHist2D("etaVsPcoarse", kin->pLab, kin->etaLab, wTrack);
+    H->FillHist1D("z",  kin->z,  wgt);
+    H->FillHist1D("pT", kin->pT, wgt);
+    H->FillHist1D("qT", kin->qT, wgt);
+    if(kin->Q2!=0) H->FillHist1D("qTq",kin->qT/TMath::Sqrt(kin->Q2),wgt);
+    H->FillHist1D("mX",         kin->mX,   wgt);
+    H->FillHist1D("phiH",       kin->phiH, wgt);
+    H->FillHist1D("phiS",       kin->phiS, wgt);
+    H->FillHist2D("phiHvsPhiS", kin->phiS, kin->phiH, wgt);
+    H->FillHist1D("phiSivers",  Kinematics::AdjAngle(kin->phiH - kin->phiS), wgt);
+    H->FillHist1D("phiCollins", Kinematics::AdjAngle(kin->phiH + kin->phiS), wgt);
+    H->FillHist2D("etaVsP",       kin->pLab, kin->etaLab, wgt); // TODO: lab-frame p, or some other frame?
+    H->FillHist2D("etaVsPcoarse", kin->pLab, kin->etaLab, wgt);
     // depolarization
     if(includeOutputSet["depolarization"]) { // not necessary, but done for performance
       std::map<TString,Double_t> depols = {
@@ -766,96 +792,82 @@ void Analysis::FillHistosTracks() {
         { "depolWA", kin->depolP4 }
       };
       for(auto [name,val] : depols) {
-        H->FillHist2D(name+"vsQ2",    kin->Q2, val,     wTrack);
-        H->FillHist2D(name+"vsY",     kin->y,  val,     wTrack);
-        H->FillHist3D(name+"vsQ2vsX", kin->x,  kin->Q2, val, wTrack);
+        H->FillHist2D(name+"vsQ2",    kin->Q2, val,     wgt);
+        H->FillHist2D(name+"vsY",     kin->y,  val,     wgt);
+        H->FillHist3D(name+"vsQ2vsX", kin->x,  kin->Q2, val, wgt);
       }
     }
     // cross sections (divide by lumi after all events processed)
-    H->FillHist1D("Q_xsec", TMath::Sqrt(kin->Q2), wTrack);
+    H->FillHist1D("Q_xsec", TMath::Sqrt(kin->Q2), wgt);
     // resolutions
-    H->FillHist1D("x_Res",  kin->x - kinTrue->x,   wTrack );
-    H->FillHist1D("y_Res",  kin->y - kinTrue->y,   wTrack );
-    H->FillHist1D("Q2_Res", kin->Q2 - kinTrue->Q2, wTrack );
-    H->FillHist1D("W_Res",  kin->W - kinTrue->W,   wTrack );
-    H->FillHist1D("Nu_Res", kin->Nu - kinTrue->Nu, wTrack );
-    H->FillHist1D("phiH_Res",  Kinematics::AdjAngle(kin->phiH - kinTrue->phiH), wTrack );
-    H->FillHist1D("phiS_Res",  Kinematics::AdjAngle(kin->phiS - kinTrue->phiS), wTrack );
-    H->FillHist1D("pT_Res",    kin->pT - kinTrue->pT, wTrack );
-    H->FillHist1D("z_Res",     kin->z - kinTrue->z,   wTrack );
-    H->FillHist1D("mX_Res",    kin->mX - kinTrue->mX, wTrack );
-    H->FillHist1D("xF_Res",    kin->xF - kinTrue->xF, wTrack );
-    H->FillHist2D("Q2vsXtrue", kinTrue->x,            kinTrue->Q2, wTrack);
+    H->FillHist1D("x_Res",  kin->x - kinTrue->x,   wgt );
+    H->FillHist1D("y_Res",  kin->y - kinTrue->y,   wgt );
+    H->FillHist1D("Q2_Res", kin->Q2 - kinTrue->Q2, wgt );
+    H->FillHist1D("W_Res",  kin->W - kinTrue->W,   wgt );
+    H->FillHist1D("Nu_Res", kin->Nu - kinTrue->Nu, wgt );
+    H->FillHist1D("phiH_Res",  Kinematics::AdjAngle(kin->phiH - kinTrue->phiH), wgt );
+    H->FillHist1D("phiS_Res",  Kinematics::AdjAngle(kin->phiS - kinTrue->phiS), wgt );
+    H->FillHist1D("pT_Res",    kin->pT - kinTrue->pT, wgt );
+    H->FillHist1D("z_Res",     kin->z - kinTrue->z,   wgt );
+    H->FillHist1D("mX_Res",    kin->mX - kinTrue->mX, wgt );
+    H->FillHist1D("xF_Res",    kin->xF - kinTrue->xF, wgt );
+    H->FillHist2D("Q2vsXtrue", kinTrue->x,            kinTrue->Q2, wgt);
     if(kinTrue->z!=0)
-      H->FillHist2D("Q2vsX_zres", kinTrue->x, kinTrue->Q2, wTrack*( fabs(kinTrue->z - kin->z)/(kinTrue->z) ) );
+      H->FillHist2D("Q2vsX_zres", kinTrue->x, kinTrue->Q2, wgt*( fabs(kinTrue->z - kin->z)/(kinTrue->z) ) );
     if(kinTrue->pT!=0)
-      H->FillHist2D("Q2vsX_pTres", kinTrue->x, kinTrue->Q2, wTrack*( fabs(kinTrue->pT - kin->pT)/(kinTrue->pT) ) );
-    H->FillHist2D("Q2vsX_phiHres", kinTrue->x, kinTrue->Q2, wTrack*( fabs(Kinematics::AdjAngle(kinTrue->phiH - kin->phiH) ) ) );
-    
+      H->FillHist2D("Q2vsX_pTres", kinTrue->x, kinTrue->Q2, wgt*( fabs(kinTrue->pT - kin->pT)/(kinTrue->pT) ) );
+    H->FillHist2D("Q2vsX_phiHres", kinTrue->x, kinTrue->Q2, wgt*( fabs(Kinematics::AdjAngle(kinTrue->phiH - kin->phiH) ) ) );
+
     auto htrue = H->Hist("Q2vsXtrue",true);
     if(htrue!=nullptr) {
       if( htrue->FindBin(kinTrue->x,kinTrue->Q2) == htrue->FindBin(kin->x,kin->Q2) )
-        H->FillHist2D("Q2vsXpurity", kin->x, kin->Q2, wTrack);
+        H->FillHist2D("Q2vsXpurity", kin->x, kin->Q2, wgt);
     }
-    
     // -- reconstructed vs. generated
-    H->FillHist2D("x_RvG",    kinTrue->x,    kin->x,    wTrack);
-    H->FillHist2D("phiH_RvG", kinTrue->phiH, kin->phiH, wTrack);
-    H->FillHist2D("phiS_RvG", kinTrue->phiS, kin->phiS, wTrack);
-  });
-  // execute the payload
-  // - save time and don't call `ClearOps` (next loop will overwrite lambda)
-  // - called with `activeNodesOnly==true` since we only want to fill bins associated
-  //   with this track
-  HD->ExecuteOps(true);
+    H->FillHist2D("x_RvG",    kinTrue->x,    kin->x,    wgt);
+    H->FillHist2D("phiH_RvG", kinTrue->phiH, kin->phiH, wgt);
+    H->FillHist2D("phiS_RvG", kinTrue->phiS, kin->phiS, wgt);
+  };
+  FillHistos(fill_payload);
 };
 
-
-// jets
+// fill jet histograms
+void Analysis::FillHistosJets(Double_t wgt) {
 #ifndef EXCLUDE_DELPHES
-void Analysis::FillHistosJets() {
-
-  // check which bins to fill
-  HD->CheckBins();
-
-  // fill histograms, for activated bins only
-  HD->Payload([this](Histos *H){
-    H->FillHist2D("Q2vsX",   kin->x,     kin->Q2, wJet);
+  auto fill_payload = [this,wgt] (Histos *H) {
+    H->FillHist2D("Q2vsX",   kin->x,     kin->Q2, wgt);
     // jet kinematics
-    H->FillHist1D("JetPT",  kin->pTjet,  wJet);
-    H->FillHist1D("JetMT",  kin->mTjet,  wJet);
-    H->FillHist1D("JetZ",   kin->zjet,   wJet);
-    H->FillHist1D("JetEta", kin->etajet, wJet);
-    H->FillHist1D("JetQT",  kin->qTjet,  wJet);
-    H->FillHist1D("JetE",   kin->ejet,   wJet);
-    H->FillHist1D("JetM",   kin->mjet,   wJet);
+    H->FillHist1D("JetPT",  kin->pTjet,  wgt);
+    H->FillHist1D("JetMT",  kin->mTjet,  wgt);
+    H->FillHist1D("JetZ",   kin->zjet,   wgt);
+    H->FillHist1D("JetEta", kin->etajet, wgt);
+    H->FillHist1D("JetQT",  kin->qTjet,  wgt);
+    H->FillHist1D("JetE",   kin->ejet,   wgt);
+    H->FillHist1D("JetM",   kin->mjet,   wgt);
 
-    H->FillHist2D("JetPTVsEta", kin->etajet, kin->pTjet, wJet);
+    H->FillHist2D("JetPTVsEta", kin->etajet, kin->pTjet, wgt);
 
     // Fill Resolution Histos
-    H->FillHist1D("JetDeltaR", kin->deltaRjet, wJet);
+    H->FillHist1D("JetDeltaR", kin->deltaRjet, wgt);
 
-    H->FillHist2D("JetPTTrueVsReco", kin->pTjet, kin->pTmtjet, wJet);
-    H->FillHist2D("JetETrueVsReco", kin->ejet, kin->emtjet, wJet);
+    H->FillHist2D("JetPTTrueVsReco", kin->pTjet, kin->pTmtjet, wgt);
+    H->FillHist2D("JetETrueVsReco", kin->ejet, kin->emtjet, wgt);
 
-    H->FillHist2D("JetResPTVsTruePT", kin->pTmtjet, (kin->pTjet - kin->pTmtjet)/(kin->pTmtjet), wJet);
-    H->FillHist2D("JetResEVsTrueE", kin->emtjet, (kin->ejet - kin->emtjet)/(kin->emtjet), wJet);
- 
-    H->FillHist2D("JetResPTVsRecoPT", kin->pTjet, (kin->pTjet - kin->pTmtjet)/(kin->pTmtjet), wJet);
-    H->FillHist2D("JetResEVsRecoE", kin->ejet, (kin->ejet - kin->emtjet)/(kin->emtjet), wJet);
+    H->FillHist2D("JetResPTVsTruePT", kin->pTmtjet, (kin->pTjet - kin->pTmtjet)/(kin->pTmtjet), wgt);
+    H->FillHist2D("JetResEVsTrueE", kin->emtjet, (kin->ejet - kin->emtjet)/(kin->emtjet), wgt);
 
-    if(kin->Q2!=0) H->FillHist1D("JetQTQ", kin->qTjet/sqrt(kin->Q2), wJet);
+    H->FillHist2D("JetResPTVsRecoPT", kin->pTjet, (kin->pTjet - kin->pTmtjet)/(kin->pTmtjet), wgt);
+    H->FillHist2D("JetResEVsRecoE", kin->ejet, (kin->ejet - kin->emtjet)/(kin->emtjet), wgt);
+
+    if(kin->Q2!=0) H->FillHist1D("JetQTQ", kin->qTjet/sqrt(kin->Q2), wgt);
     for(int j = 0; j < kin->jperp.size(); j++) {
-      H->FillHist1D("JetJperp", kin->jperp[j], wJet);
+      H->FillHist1D("JetJperp", kin->jperp[j], wgt);
     };
-  });
-  // execute the payload
-  // - save time and don't call `ClearOps` (next loop will overwrite lambda)
-  // - called with `activeNodesOnly==true` since we only want to fill bins associated
-  //   with this jet
-  HD->ExecuteOps(true);
-};
+  };
+  FillHistos(fill_payload);
 #endif
+};
+
 
 // print an error; if more than `errorCntMax` errors are printed, printing is suppressed
 void Analysis::ErrorPrint(std::string message) {

--- a/src/Analysis.h
+++ b/src/Analysis.h
@@ -87,8 +87,8 @@ class Analysis : public TNamed
 
 
     // set weights // TODO: are these used yet?
-    void SetWeights(Weights const* w) { weight = w; }
-    void SetWeightsJet(Weights const* w) { weightJet = w; }
+    // void SetWeightsTrack(Weights const* w) { weightTrack = w; }
+    // void SetWeightsJet(Weights const* w) { weightJet = w; }
 
     Double_t GetEventQ2Weight(Double_t Q2, Int_t guess=0);
     // after adding all files, estimate the weights for events in each Q2 range
@@ -111,19 +111,19 @@ class Analysis : public TNamed
     // print an error; if more than `errorCntMax` errors are printed, printing is suppressed
     void ErrorPrint(std::string message);
 
-    // FillHistos methods: fill histograms
-    void FillHistosTracks();
-#ifndef EXCLUDE_DELPHES
-    void FillHistosJets();
-#endif
+    // `FillHistos(weight)` methods: fill histograms
+    void FillHistosInclusive(Double_t wgt); // inclusive kinematics
+    void FillHistos1h(Double_t wgt);        // single-hadron kinematics
+    void FillHistosJets(Double_t wgt);      // jet kinematics
 
     // shared objects
     SimpleTree *ST;
     Kinematics *kin, *kinTrue;
     HistosDAG *HD;
-    Weights const* weight;
+    Weights const* weightInclusive;
+    Weights const* weightTrack;
     Weights const* weightJet;
-    Double_t wTrackTotal, wJetTotal;
+    Double_t wInclusiveTotal, wTrackTotal, wJetTotal;
     Long64_t entriesTot;
     Long64_t errorCnt;
     const TString sep = "--------------------------------------------";
@@ -152,7 +152,6 @@ class Analysis : public TNamed
     Double_t elePtrue, maxElePtrue;
     int pid;
     TString finalStateID;
-    Double_t wTrack,wJet;
 #ifndef EXCLUDE_DELPHES
     fastjet::PseudoJet jet;
 #endif
@@ -193,6 +192,10 @@ class Analysis : public TNamed
       fmt::print("}}\n");
     }
 
+  private:
+
+    // fill histograms, according to `fill_payload`
+    void FillHistos(std::function<void(Histos*)> fill_payload);
 
   ClassDef(Analysis,1);
 };

--- a/src/AnalysisAthena.cxx
+++ b/src/AnalysisAthena.cxx
@@ -206,6 +206,16 @@ void AnalysisAthena::Execute()
     if(!(kin->CalculateDIS(reconMethod))) continue; // reconstructed
     if(!(kinTrue->CalculateDIS(reconMethod))) continue; // generated (truth)
 
+    // Get the weight for this event's Q2
+    auto Q2weightFactor = GetEventQ2Weight(kinTrue->Q2, inLookup[chain->GetTreeNumber()]);
+
+    // fill inclusive histograms, if only `inclusive` is included in output
+    // (otherwise they will be filled in track and jet loops)
+    if(includeOutputSet["inclusive_only"]) {
+      auto wInclusive = Q2weightFactor * weightInclusive->GetWeight(*kinTrue);
+      wInclusiveTotal += wInclusive;
+      FillHistosInclusive(wInclusive);
+    }
 
     // loop over reconstructed particles again
     /* - calculate hadron kinematics
@@ -259,13 +269,13 @@ void AnalysisAthena::Execute()
       // kin->tSpin = kinTrue->tSpin; // copy to "reconstructed" tSpin
 
       // weighting
-      Double_t Q2weightFactor = GetEventQ2Weight(kinTrue->Q2, inLookup[chain->GetTreeNumber()]);
-      wTrack = Q2weightFactor * weight->GetWeight(*kinTrue);
+      auto wTrack = Q2weightFactor * weightTrack->GetWeight(*kinTrue);
       wTrackTotal += wTrack;
 
       if(includeOutputSet["1h"]) {
-        // fill track histograms in activated bins
-        FillHistosTracks();
+        // fill single-hadron histograms in activated bins
+        FillHistos1h(wTrack);
+        FillHistosInclusive(wTrack);
 
         // fill simple tree
         // - not binned

--- a/src/AnalysisDelphes.cxx
+++ b/src/AnalysisDelphes.cxx
@@ -151,12 +151,17 @@ void AnalysisDelphes::Execute() {
     if(!(kin->CalculateDIS(reconMethod))) continue; // reconstructed
     if(!(kinTrue->CalculateDIS(reconMethod))) continue; // generated (truth)
 
-    // get vector of jets
-    // TODO: should this have an option for clustering method?
-    if(includeOutputSet["jets"])
-      //kin->GetJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);
-      kin->GetJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle, jetAlg, jetRad, jetMin);
-   
+    // Get the weight for this event's Q2
+    auto Q2weightFactor = GetEventQ2Weight(kinTrue->Q2, inLookup[chain->GetTreeNumber()]);
+
+    // fill inclusive histograms, if only `inclusive` is included in output
+    // (otherwise they will be filled in track and jet loops)
+    if(includeOutputSet["inclusive_only"]) {
+      auto wInclusive = Q2weightFactor * weightInclusive->GetWeight(*kinTrue);
+      wInclusiveTotal += wInclusive;
+      FillHistosInclusive(wInclusive);
+    }
+
     // track loop - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     itTrack.Reset();
     while(Track *trk = (Track*) itTrack()) {
@@ -208,14 +213,12 @@ void AnalysisDelphes::Execute() {
       //kinTrue->InjectFakeAsymmetry(); // sets tSpin, based on generated kinematics
       //kin->tSpin = kinTrue->tSpin; // copy to "reconstructed" tSpin
   
-      // Get index of file that the event comes from.
-      Double_t Q2weightFactor = GetEventQ2Weight(kinTrue->Q2, inLookup[chain->GetTreeNumber()]);
-      wTrack = Q2weightFactor * weight->GetWeight(*kinTrue);
-      wTrackTotal += wTrack;
-
       if(includeOutputSet["1h"]) {
-        // fill track histograms in activated bins
-        FillHistosTracks();
+        // fill single-hadron histograms in activated bins
+        auto wTrack = Q2weightFactor * weightTrack->GetWeight(*kinTrue);
+        wTrackTotal += wTrack;
+        FillHistos1h(wTrack);
+        FillHistosInclusive(wTrack);
 
         // fill simple tree
         // - not binned
@@ -231,14 +234,19 @@ void AnalysisDelphes::Execute() {
 
     // jet loop - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     if(includeOutputSet["jets"]) {
+
+      // get vector of jets
+      // TODO: should this have an option for clustering method?
+      //kin->GetJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);
+      kin->GetJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle, jetAlg, jetRad, jetMin);
+
       finalStateID = "jet";
 
 #ifdef INCLUDE_CENTAURO
       if(useBreitJets) kin->GetBreitFrameJets(itEFlowTrack, itEFlowPhoton, itEFlowNeutralHadron, itParticle);
 #endif
 
-      Double_t Q2weightFactor = GetEventQ2Weight(kinTrue->Q2, inLookup[chain->GetTreeNumber()]);
-      wJet = Q2weightFactor * weightJet->GetWeight(*kinTrue); // TODO: should we separate weights for breit and non-breit jets?
+      auto wJet = Q2weightFactor * weightJet->GetWeight(*kinTrue); // TODO: should we separate weights for breit and non-breit jets?
       wJetTotal += wJet;
 
       Int_t nJets;
@@ -261,7 +269,8 @@ void AnalysisDelphes::Execute() {
         };
 
         // fill jet histograms in activated bins
-        FillHistosJets();
+        FillHistosJets(wJet);
+        FillHistosInclusive(wJet);
 
       };
     }; // end jet loop

--- a/src/AnalysisEcce.cxx
+++ b/src/AnalysisEcce.cxx
@@ -292,6 +292,16 @@ void AnalysisEcce::Execute()
     if(!(kin->CalculateDIS(reconMethod))) continue; // reconstructed
     if(!(kinTrue->CalculateDIS(reconMethod))) continue; // generated (truth)
 
+    // Get the weight for this event's Q2
+    auto Q2weightFactor = GetEventQ2Weight(kinTrue->Q2, inLookup[chain->GetTreeNumber()]);
+
+    // fill inclusive histograms, if only `inclusive` is included in output
+    // (otherwise they will be filled in track and jet loops)
+    if(includeOutputSet["inclusive_only"]) {
+      auto wInclusive = Q2weightFactor * weightInclusive->GetWeight(*kinTrue);
+      wInclusiveTotal += wInclusive;
+      FillHistosInclusive(wInclusive);
+    }
 
     // loop over reconstructed particles again
     /* - calculate hadron kinematics
@@ -345,13 +355,13 @@ void AnalysisEcce::Execute()
       // kin->tSpin = kinTrue->tSpin; // copy to "reconstructed" tSpin
 
       // weighting
-      Double_t Q2weightFactor = GetEventQ2Weight(kinTrue->Q2, inLookup[chain->GetTreeNumber()]);
-      wTrack = Q2weightFactor * weight->GetWeight(*kinTrue);
+      auto wTrack = Q2weightFactor * weightTrack->GetWeight(*kinTrue);
       wTrackTotal += wTrack;
 
       if(includeOutputSet["1h"]) {
-        // fill track histograms in activated bins
-        FillHistosTracks();
+        // fill single-hadron histograms in activated bins
+        FillHistos1h(wTrack);
+        FillHistosInclusive(wTrack);
 
         // fill simple tree
         // - not binned


### PR DESCRIPTION
### Briefly, what does this PR introduce?
- add `FillHistosInclusive` method, for filling inclusive histograms
  - if **only** inclusive kinematics are included in the output, these distributions will be filled once per event; otherwise they will be filled in the track and jet loops
- rename `FillHistosTracks` -> `FillHistos1h`
- add weight argument to the `FillHistos*` methods
- add a 3rd weight for inclusive kinematics
- currently leaving `depolarization` output set coupled with the `1h` set


### What kind of change does this PR introduce?
- [x] Bug fix (issue #205)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators
  - @bspage912: this will make sure the inclusive histograms get filled in the `jet` final state
  - @Gregtom3: the changes in `AnalysisEpic` will need to be propagated to your branch

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no