### PR TITLE
chore: rename `AnalysisEpic` -> `AnalysisEpicPodio`

### DIFF
--- a/src/AnalysisEpicPodio.cxx
+++ b/src/AnalysisEpicPodio.cxx
@@ -1,13 +1,13 @@
-#include "AnalysisEpic.h"
+#include "AnalysisEpicPodio.h"
 
-AnalysisEpic::AnalysisEpic(TString infileName_, TString outfilePrefix_)
+AnalysisEpicPodio::AnalysisEpicPodio(TString infileName_, TString outfilePrefix_)
   : Analysis(infileName_, outfilePrefix_)
   , crossCheckKinematics(false)
 {};
 
-AnalysisEpic::~AnalysisEpic() {};
+AnalysisEpicPodio::~AnalysisEpicPodio() {};
 
-void AnalysisEpic::Execute()
+void AnalysisEpicPodio::Execute()
 {
   // setup
   Prepare();
@@ -330,7 +330,7 @@ void AnalysisEpic::Execute()
 
 // particle printers //////////////////////////////////////////////
 
-void AnalysisEpic::PrintParticle(const edm4hep::MCParticle& P) { 
+void AnalysisEpicPodio::PrintParticle(const edm4hep::MCParticle& P) { 
   fmt::print("\n");
   fmt::print("  {:>20}: {}\n", "PDG",          P.getPDG()             );
   fmt::print("  {:>20}: {}\n", "Status",       P.getGeneratorStatus() );
@@ -357,7 +357,7 @@ void AnalysisEpic::PrintParticle(const edm4hep::MCParticle& P) {
     fmt::print("    {:>20}: {}\n", "PDG", daughter.getPDG());
 }
 
-void AnalysisEpic::PrintParticle(const edm4eic::ReconstructedParticle& P) {
+void AnalysisEpicPodio::PrintParticle(const edm4eic::ReconstructedParticle& P) {
   fmt::print("\n");
   fmt::print("  {:>20}: ", "PDG");
   if(P.getParticleIDUsed().isAvailable()) fmt::print("{}\n", P.getParticleIDUsed().getPDG());
@@ -394,7 +394,7 @@ void AnalysisEpic::PrintParticle(const edm4eic::ReconstructedParticle& P) {
  * - execute `payload`
 //     payload signature: (simPart, recPart, reconstructed PDG)
  */
-void AnalysisEpic::LoopMCRecoAssocs(
+void AnalysisEpicPodio::LoopMCRecoAssocs(
     const edm4eic::MCRecoParticleAssociationCollection& mcRecAssocs,
     std::function<void(const edm4hep::MCParticle&, const edm4eic::ReconstructedParticle&, int)> payload,
     bool printParticles
@@ -434,7 +434,7 @@ void AnalysisEpic::LoopMCRecoAssocs(
 
 // get PDG from reconstructed particle; resort to true PDG, if
 // PID is unavailable (sets `usedTruth` to true)
-int AnalysisEpic::GetReconstructedPDG(
+int AnalysisEpicPodio::GetReconstructedPDG(
     const edm4hep::MCParticle& simPart,
     const edm4eic::ReconstructedParticle& recPart,
     bool& usedTruth

--- a/src/AnalysisEpicPodio.h
+++ b/src/AnalysisEpicPodio.h
@@ -1,5 +1,4 @@
-#ifndef AnalysisEpic_
-#define AnalysisEpic_
+#pragma once
 
 // data model
 #include "podio/EventStore.h"
@@ -17,11 +16,11 @@
 #include "Analysis.h"
 
 
-class AnalysisEpic : public Analysis
+class AnalysisEpicPodio : public Analysis
 {
   public:
-    AnalysisEpic(TString infileName_="", TString outfilePrefix_="");
-    ~AnalysisEpic();
+    AnalysisEpicPodio(TString infileName_="", TString outfilePrefix_="");
+    ~AnalysisEpicPodio();
 
     void Execute() override;
 
@@ -64,7 +63,5 @@ class AnalysisEpic : public Analysis
     podio::ROOTReader podioReader;
     podio::EventStore evStore;
 
-    ClassDefOverride(AnalysisEpic,1);
+    ClassDefOverride(AnalysisEpicPodio,1);
 };
-
-#endif

--- a/src/LinkDef.h
+++ b/src/LinkDef.h
@@ -24,6 +24,7 @@
 // analysis event loop classes
 #pragma link C++ class Analysis+;
 #pragma link C++ class AnalysisEpic+;
+#pragma link C++ class AnalysisEpicPodio+;
 #pragma link C++ class AnalysisAthena+;
 #pragma link C++ class AnalysisEcce+;
 #ifndef EXCLUDE_DELPHES


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Preserve `PODIO` collection dependent version of `AnalysisEpic` as `AnalysisEpicPodio`, to be ready for when `EICrecon` has full `PODIO`-compliant output available.

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [x] Other: __

### Please check if this PR fulfills the following:
- [x] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [x] Changes have been communicated to collaborators: @Gregtom3 

### Does this PR introduce breaking changes? What changes might users need to make to their code?
no

### Does this PR change default behavior?
no